### PR TITLE
fix: matplotlib style sheet not found

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   
   workflow_dispatch:
   push:
-    branches: [main, dev, nh/fix-mpl-style-sheet-not-found]
+    branches: [main, dev]
 
 jobs:
 


### PR DESCRIPTION
## Description

After removing the old, unused matplotlib style sheet there was an [error](https://github.com/best-practice-and-impact/afcharts-py/actions/runs/20712165194/job/59454976690) in the render-cookbook workflow:

```python
OSError: 'afcharts.afcharts' is not a valid package style, path of style file, URL of style file, or library style name (library styles are listed in `style.available`)
```


## Changes Made
Removed the contents of the __init__.py file, which was attempting to load a (now non-existent) style sheet.
