### PR TITLE
fix(mpl): include style sheet in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ where = ["src"]                                # Packages are located in src/ to
 exclude = ["docs*", "Documentation*", "build"]
 
 [tool.setuptools.package-data]
-afcharts = ["stylelib/*.mplstyle"]
+afcharts = ["*.mplstyle"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Bug fix: The new matplotlib style sheet was being ignored during install by default because it's not a standard python file. This PR explicitly adds the latest style sheet, which replaces the old style sheet that used to live in the stylelib/ subdirectory.

I've tested that this works with a fresh install of the package from this commit using: `pip install git+https://github.com/best-practice-and-impact/afcharts-py.git@2497513196c969267ac949c2f2a5e7dd5aad1e58`
