### PR TITLE
docs: matplotlib cookbook annotations

### DIFF
--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -589,7 +589,11 @@ This bar chart uses the afcharts theme, and shows the populations of five countr
 
 ## Annotations
 
-Annotations can be used to add value labels to a bar chart. Use the `bar_label()` method to add labels to bars in a bar chart. In the example below, the population values are added as white text labels inside the bars.
+Labelling your chart is often preferable to using a legend, as often this relies on a user matching the legend to the data using colour alone.
+
+You can add an annotation anywhere on a chart using the `annotate()` method. This is demonstrated above in [Line chart with duo palette](#line-chart-with-duo-palette), which directly labels each line. Note that black text has been used for the labels, as this ensures sufficient contrast against the white background.
+
+To add value labels to bars in a bar chart, use the `bar_label()` method. In the example below, the population values are added as white text labels inside the bars.
 
 ```{python}
 #| output: false

--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -587,6 +587,56 @@ fig
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
 </div>
 
+## Annotations
+
+Annotations can be used to add value labels to a bar chart. Use the `bar_label()` method to add labels to bars in a bar chart. In the example below, the population values are added as white text labels inside the bars.
+
+```{python}
+#| output: false
+import matplotlib.pyplot as plt
+
+# Load gapminder dataset from plotly
+from plotly.express.data import gapminder
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+# Filter for Americas in 2007 and get top 5 by population
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+
+top5 = df.nlargest(5, "pop")
+
+fig, ax = plt.subplots()
+
+bars = ax.bar(
+    top5["country"],
+    top5["pop"] / 1e6,  # Convert to millions
+)
+
+# Add text annotations to top of each bar
+ax.bar_label(bars, labels=[f'{round(val, 1)}' for val in top5["pop"] / 1e6],
+             color='white', padding=-15)
+
+fig
+```
+
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="barchart-annotated-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="barchart-annotated-desc">
+This bar chart uses the afcharts theme, and shows the populations of the five most populous countries in the Americas. Each bar is dark blue and labelled by country underneath. White text labels are added inside each bar showing the population value in millions. Pale grey grid lines extend out from the y axis.
+</div>
+
 ## Other customisations
 ### Sorting a bar chart
 


### PR DESCRIPTION
## Description

### Summary
<!-- Provide a brief description of the changes in this PR -->

Adds an 'annotations' section to the matplotlib cookbook.

## Changes Made
<!-- List the main changes made in this PR -->

As above. I only recreated the bar chart example that's used in the R cookbook. Given that we have avoided using legends in our line charts, it makes the examples that have been included in the R cookbook redundant (they're effectively using the annotations section to achieve best practice). There are other ways to annotate visuals using annotate() with matplotlib, but not sure we want to be getting into that here. Let me know if you disagree!

### Related Issues
<!-- Link to related issues using keywords like "Fixes #123", "Closes #456", "Relates to #789" -->
- Relates to #55
- Closes #157 
