### PR TITLE
feat: type hints

### DIFF
--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -6,9 +6,10 @@
 from pathlib import Path
 
 import yaml
+from typing import List, Optional, Union
 
 
-def get_af_colours(palette: str, colour_format="hex", number_of_colours=6, config_path=None):
+def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: int=6, config_path: Optional[Path]=None):
     """
     get_af_colours() is the top level function in af_colours. This returns
     the chosen Analysis Function colour palette in hex or rgb format.
@@ -43,7 +44,7 @@ def get_af_colours(palette: str, colour_format="hex", number_of_colours=6, confi
 
     Returns
     -------
-    list
+    List[str]
         chosen_colours_list
 
     """
@@ -82,7 +83,7 @@ def get_af_colours(palette: str, colour_format="hex", number_of_colours=6, confi
     return chosen_colours_list
 
 
-def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex", number_of_colours=2):
+def categorical_colours(categorical_hex_list: list, duo_hex_list: list, colour_format: str="hex", number_of_colours: int=2):
     """
     Return the Analysis Function categorical colour palette as a list
     in hex or rgb format for up to 6 colours. If number_of_colours is
@@ -90,10 +91,10 @@ def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex",
 
     Parameters
     ----------
-    categorical_hex_list : list
+    categorical_hex_list : List[str]
         List of categorical colours as a hex list, stored in the config.
 
-    duo_hex_list : list
+    duo_hex_list : List[str]
         List of duo hex codes, stored in the config. This is needed for the
         case of number_of_colours = 2.
 
@@ -111,7 +112,7 @@ def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex",
 
     Returns
     -------
-    list
+    List[str]
         categorical_colours_list
 
     """
@@ -137,7 +138,7 @@ def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex",
     return categorical_colours_list
 
 
-def duo_colours(duo_hex_list, colour_format="hex"):
+def duo_colours(duo_hex_list: list, colour_format: str="hex"):
     """
     Return the Analysis Function duo colour palette as a list of 2
     colours in hex or rgb format. This function is also called by
@@ -145,7 +146,7 @@ def duo_colours(duo_hex_list, colour_format="hex"):
 
     Parameters
     ----------
-    duo_hex_list : list
+    duo_hex_list : List[str]
         List of duo colours hex codes, stored in the config. This is needed for the
         case of number_of_colours = 2.
 
@@ -154,7 +155,7 @@ def duo_colours(duo_hex_list, colour_format="hex"):
 
     Returns
     -------
-    list
+    List[str]
         duo_colours_list
 
     """
@@ -169,22 +170,22 @@ def duo_colours(duo_hex_list, colour_format="hex"):
     return duo_colours_list
 
 
-def sequential_colours(sequential_hex_list, colour_format="hex"):
+def sequential_colours(sequential_hex_list: list, colour_format: str="hex"):
     """
     Return the Analysis Function sequential colour palette as a list
     of 3 colours in hex or rgb format.
 
     Parameters
     ----------
-    sequential_hex_list : list
+    sequential_hex_list : List[str]
         List of sequential colours hex codes, stored in the config.
 
-    colour_format : string
+    colour_format : List[str]
         Colour format required, with accepted values of "hex" or "rgb".
 
     Returns
     -------
-    list
+    List[str]
         sequential_colours_list
 
     """
@@ -199,14 +200,14 @@ def sequential_colours(sequential_hex_list, colour_format="hex"):
     return sequential_colours_list
 
 
-def focus_colours(focus_hex_list, colour_format="hex"):
+def focus_colours(focus_hex_list: list, colour_format: str="hex"):
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.
 
     Parameters
     ----------
-    focus_hex_list : list
+    focus_hex_list : List[str]
         List of focus colours hex codes, stored in the config.
 
     colour_format : string
@@ -214,7 +215,7 @@ def focus_colours(focus_hex_list, colour_format="hex"):
 
     Returns
     -------
-    list
+    List[str]
         focus_colours_list
 
     """
@@ -229,13 +230,13 @@ def focus_colours(focus_hex_list, colour_format="hex"):
     return focus_colours_list
 
 
-def hex_to_rgb(hex_colours):
+def hex_to_rgb(hex_colours: list):
     """
     Convert a list of hex codes to a list of rgb colours.
 
     Parameters
     ----------
-    hex_colours : list
+    hex_colours : List[str]
         The hex colours to be converted as a list of strings, with or
         without # at the beginning.
 
@@ -246,7 +247,7 @@ def hex_to_rgb(hex_colours):
 
     Returns
     -------
-    list
+    List[Tuple[int, int, int]]
         converted_list
 
     """

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -4,12 +4,14 @@
 # Py-af-colours source: https://github.com/best-practice-and-impact/py-af-colours
 
 from pathlib import Path
+from typing import List, Optional, Tuple, Union
 
 import yaml
-from typing import List, Tuple, Optional, Union
 
 
-def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: int=6, config_path: Optional[Path]=None) -> List[Union[str, Tuple[int, int, int]]]:
+def get_af_colours(
+    palette: str, colour_format: str = "hex", number_of_colours: int = 6, config_path: Optional[Path] = None
+) -> List[Union[str, Tuple[int, int, int]]]:
     """
     get_af_colours() is the top level function in af_colours. This returns
     the chosen Analysis Function colour palette in hex or rgb format.
@@ -83,7 +85,9 @@ def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: in
     return chosen_colours_list
 
 
-def categorical_colours(categorical_hex_list: List[str], duo_hex_list: List[str], colour_format: str="hex", number_of_colours: int=2) -> List[Union[str, Tuple[int, int, int]]]:
+def categorical_colours(
+    categorical_hex_list: List[str], duo_hex_list: List[str], colour_format: str = "hex", number_of_colours: int = 2
+) -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function categorical colour palette as a list
     in hex or rgb format for up to 6 colours. If number_of_colours is
@@ -138,7 +142,7 @@ def categorical_colours(categorical_hex_list: List[str], duo_hex_list: List[str]
     return categorical_colours_list
 
 
-def duo_colours(duo_hex_list: List[str], colour_format: str="hex") -> List[Union[str, Tuple[int, int, int]]]:
+def duo_colours(duo_hex_list: List[str], colour_format: str = "hex") -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function duo colour palette as a list of 2
     colours in hex or rgb format. This function is also called by
@@ -170,7 +174,9 @@ def duo_colours(duo_hex_list: List[str], colour_format: str="hex") -> List[Union
     return duo_colours_list
 
 
-def sequential_colours(sequential_hex_list: List[str], colour_format: str="hex") -> List[Union[str, Tuple[int, int, int]]]:
+def sequential_colours(
+    sequential_hex_list: List[str], colour_format: str = "hex"
+) -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function sequential colour palette as a list
     of 3 colours in hex or rgb format.
@@ -200,7 +206,7 @@ def sequential_colours(sequential_hex_list: List[str], colour_format: str="hex")
     return sequential_colours_list
 
 
-def focus_colours(focus_hex_list: List[str], colour_format: str="hex") -> List[Union[str, Tuple[int, int, int]]]:
+def focus_colours(focus_hex_list: List[str], colour_format: str = "hex") -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -6,10 +6,10 @@
 from pathlib import Path
 
 import yaml
-from typing import List, Optional, Union
+from typing import List, Tuple, Optional, Union
 
 
-def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: int=6, config_path: Optional[Path]=None):
+def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: int=6, config_path: Optional[Path]=None) -> List[Union[str, Tuple[int, int, int]]]:
     """
     get_af_colours() is the top level function in af_colours. This returns
     the chosen Analysis Function colour palette in hex or rgb format.
@@ -44,7 +44,7 @@ def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: in
 
     Returns
     -------
-    List[str]
+    List[Union[str, Tuple[int, int, int]]]
         chosen_colours_list
 
     """
@@ -83,7 +83,7 @@ def get_af_colours(palette: str, colour_format: str="hex", number_of_colours: in
     return chosen_colours_list
 
 
-def categorical_colours(categorical_hex_list: list, duo_hex_list: list, colour_format: str="hex", number_of_colours: int=2):
+def categorical_colours(categorical_hex_list: List[str], duo_hex_list: List[str], colour_format: str="hex", number_of_colours: int=2) -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function categorical colour palette as a list
     in hex or rgb format for up to 6 colours. If number_of_colours is
@@ -112,7 +112,7 @@ def categorical_colours(categorical_hex_list: list, duo_hex_list: list, colour_f
 
     Returns
     -------
-    List[str]
+    List[Union[str, Tuple[int, int, int]]]
         categorical_colours_list
 
     """
@@ -138,7 +138,7 @@ def categorical_colours(categorical_hex_list: list, duo_hex_list: list, colour_f
     return categorical_colours_list
 
 
-def duo_colours(duo_hex_list: list, colour_format: str="hex"):
+def duo_colours(duo_hex_list: List[str], colour_format: str="hex") -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function duo colour palette as a list of 2
     colours in hex or rgb format. This function is also called by
@@ -155,7 +155,7 @@ def duo_colours(duo_hex_list: list, colour_format: str="hex"):
 
     Returns
     -------
-    List[str]
+    List[Union[str, Tuple[int, int, int]]]
         duo_colours_list
 
     """
@@ -170,7 +170,7 @@ def duo_colours(duo_hex_list: list, colour_format: str="hex"):
     return duo_colours_list
 
 
-def sequential_colours(sequential_hex_list: list, colour_format: str="hex"):
+def sequential_colours(sequential_hex_list: List[str], colour_format: str="hex") -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function sequential colour palette as a list
     of 3 colours in hex or rgb format.
@@ -180,12 +180,12 @@ def sequential_colours(sequential_hex_list: list, colour_format: str="hex"):
     sequential_hex_list : List[str]
         List of sequential colours hex codes, stored in the config.
 
-    colour_format : List[str]
+    colour_format : string
         Colour format required, with accepted values of "hex" or "rgb".
 
     Returns
     -------
-    List[str]
+    List[Union[str, Tuple[int, int, int]]]
         sequential_colours_list
 
     """
@@ -200,7 +200,7 @@ def sequential_colours(sequential_hex_list: list, colour_format: str="hex"):
     return sequential_colours_list
 
 
-def focus_colours(focus_hex_list: list, colour_format: str="hex"):
+def focus_colours(focus_hex_list: List[str], colour_format: str="hex") -> List[Union[str, Tuple[int, int, int]]]:
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.
@@ -215,7 +215,7 @@ def focus_colours(focus_hex_list: list, colour_format: str="hex"):
 
     Returns
     -------
-    List[str]
+    List[Union[str, Tuple[int, int, int]]]
         focus_colours_list
 
     """
@@ -230,7 +230,7 @@ def focus_colours(focus_hex_list: list, colour_format: str="hex"):
     return focus_colours_list
 
 
-def hex_to_rgb(hex_colours: list):
+def hex_to_rgb(hex_colours: List[str]) -> List[Tuple[int, int, int]]:
     """
     Convert a list of hex codes to a list of rgb colours.
 

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -4,13 +4,14 @@
 # Py-af-colours source: https://github.com/best-practice-and-impact/py-af-colours
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import yaml
 
+
 def get_af_colours(
     palette: str, colour_format: str = "hex", number_of_colours: int = 6, config_path: Optional[Path] = None
-):
+) -> Union[List[str], List[Tuple[int, int, int]]]:
     """
     get_af_colours() is the top level function in af_colours. This returns
     the chosen Analysis Function colour palette in hex or rgb format.
@@ -86,7 +87,7 @@ def get_af_colours(
 
 def categorical_colours(
     categorical_hex_list: List[str], duo_hex_list: List[str], colour_format: str = "hex", number_of_colours: int = 2
-):
+) -> Union[List[str], List[Tuple[int, int, int]]]:
     """
     Return the Analysis Function categorical colour palette as a list
     in hex or rgb format for up to 6 colours. If number_of_colours is
@@ -141,7 +142,7 @@ def categorical_colours(
     return categorical_colours_list
 
 
-def duo_colours(duo_hex_list: List[str], colour_format: str = "hex"):
+def duo_colours(duo_hex_list: List[str], colour_format: str = "hex") -> Union[List[str], List[Tuple[int, int, int]]]:
     """
     Return the Analysis Function duo colour palette as a list of 2
     colours in hex or rgb format. This function is also called by
@@ -175,7 +176,7 @@ def duo_colours(duo_hex_list: List[str], colour_format: str = "hex"):
 
 def sequential_colours(
     sequential_hex_list: List[str], colour_format: str = "hex"
-):
+) -> Union[List[str], List[Tuple[int, int, int]]]:
     """
     Return the Analysis Function sequential colour palette as a list
     of 3 colours in hex or rgb format.
@@ -205,7 +206,7 @@ def sequential_colours(
     return sequential_colours_list
 
 
-def focus_colours(focus_hex_list: List[str], colour_format: str = "hex"):
+def focus_colours(focus_hex_list: List[str], colour_format: str = "hex") -> Union[List[str], List[Tuple[int, int, int]]]:
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -129,7 +129,7 @@ def categorical_colours(
         return categorical_colours_list
 
     elif colour_format == "hex":
-        full_categorical_colours_list = categorical_hex_list
+        full_categorical_colours_list: Union[List[str], List[Tuple[int, int, int]]] = categorical_hex_list
 
     elif colour_format == "rgb":
         full_categorical_colours_list = hex_to_rgb(categorical_hex_list)
@@ -165,7 +165,7 @@ def duo_colours(duo_hex_list: List[str], colour_format: str = "hex") -> Union[Li
     """
 
     if colour_format == "hex":
-        duo_colours_list = duo_hex_list
+        duo_colours_list: Union[List[str], List[Tuple[int, int, int]]] = duo_hex_list
     elif colour_format == "rgb":
         duo_colours_list = hex_to_rgb(duo_hex_list)
     else:
@@ -197,7 +197,7 @@ def sequential_colours(
     """
 
     if colour_format == "hex":
-        sequential_colours_list = sequential_hex_list
+        sequential_colours_list: Union[List[str], List[Tuple[int, int, int]]] = sequential_hex_list
     elif colour_format == "rgb":
         sequential_colours_list = hex_to_rgb(sequential_hex_list)
     else:
@@ -229,7 +229,7 @@ def focus_colours(
     """
 
     if colour_format == "hex":
-        focus_colours_list = focus_hex_list
+        focus_colours_list: Union[List[str], List[Tuple[int, int, int]]] = focus_hex_list
     elif colour_format == "rgb":
         focus_colours_list = hex_to_rgb(focus_hex_list)
     else:
@@ -264,5 +264,5 @@ def hex_to_rgb(hex_colours: List[str]) -> List[Tuple[int, int, int]]:
 
     hex_colours_new = [i.lstrip("#") for i in hex_colours]
 
-    converted_list = [(tuple(int(value[i : i + 2], 16) for i in (0, 2, 4))) for value in hex_colours_new]
+    converted_list = [(int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)) for value in hex_colours_new]
     return converted_list

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -4,14 +4,13 @@
 # Py-af-colours source: https://github.com/best-practice-and-impact/py-af-colours
 
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 import yaml
 
-
 def get_af_colours(
     palette: str, colour_format: str = "hex", number_of_colours: int = 6, config_path: Optional[Path] = None
-) -> List[Union[str, Tuple[int, int, int]]]:
+):
     """
     get_af_colours() is the top level function in af_colours. This returns
     the chosen Analysis Function colour palette in hex or rgb format.
@@ -46,7 +45,7 @@ def get_af_colours(
 
     Returns
     -------
-    List[Union[str, Tuple[int, int, int]]]
+    list
         chosen_colours_list
 
     """
@@ -87,7 +86,7 @@ def get_af_colours(
 
 def categorical_colours(
     categorical_hex_list: List[str], duo_hex_list: List[str], colour_format: str = "hex", number_of_colours: int = 2
-) -> List[Union[str, Tuple[int, int, int]]]:
+):
     """
     Return the Analysis Function categorical colour palette as a list
     in hex or rgb format for up to 6 colours. If number_of_colours is
@@ -116,7 +115,7 @@ def categorical_colours(
 
     Returns
     -------
-    List[Union[str, Tuple[int, int, int]]]
+    list
         categorical_colours_list
 
     """
@@ -142,7 +141,7 @@ def categorical_colours(
     return categorical_colours_list
 
 
-def duo_colours(duo_hex_list: List[str], colour_format: str = "hex") -> List[Union[str, Tuple[int, int, int]]]:
+def duo_colours(duo_hex_list: List[str], colour_format: str = "hex"):
     """
     Return the Analysis Function duo colour palette as a list of 2
     colours in hex or rgb format. This function is also called by
@@ -159,7 +158,7 @@ def duo_colours(duo_hex_list: List[str], colour_format: str = "hex") -> List[Uni
 
     Returns
     -------
-    List[Union[str, Tuple[int, int, int]]]
+    list
         duo_colours_list
 
     """
@@ -176,7 +175,7 @@ def duo_colours(duo_hex_list: List[str], colour_format: str = "hex") -> List[Uni
 
 def sequential_colours(
     sequential_hex_list: List[str], colour_format: str = "hex"
-) -> List[Union[str, Tuple[int, int, int]]]:
+):
     """
     Return the Analysis Function sequential colour palette as a list
     of 3 colours in hex or rgb format.
@@ -191,7 +190,7 @@ def sequential_colours(
 
     Returns
     -------
-    List[Union[str, Tuple[int, int, int]]]
+    list
         sequential_colours_list
 
     """
@@ -206,7 +205,7 @@ def sequential_colours(
     return sequential_colours_list
 
 
-def focus_colours(focus_hex_list: List[str], colour_format: str = "hex") -> List[Union[str, Tuple[int, int, int]]]:
+def focus_colours(focus_hex_list: List[str], colour_format: str = "hex"):
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.
@@ -221,7 +220,7 @@ def focus_colours(focus_hex_list: List[str], colour_format: str = "hex") -> List
 
     Returns
     -------
-    List[Union[str, Tuple[int, int, int]]]
+    list
         focus_colours_list
 
     """

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -206,7 +206,9 @@ def sequential_colours(
     return sequential_colours_list
 
 
-def focus_colours(focus_hex_list: List[str], colour_format: str = "hex") -> Union[List[str], List[Tuple[int, int, int]]]:
+def focus_colours(
+    focus_hex_list: List[str], colour_format: str = "hex"
+) -> Union[List[str], List[Tuple[int, int, int]]]:
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.


### PR DESCRIPTION
## Description

### Summary
<!-- Provide a brief description of the changes in this PR -->
First attempt at addressing type hints issue. Addressed type hint issues that were causing mypy to fail in CI. Used Claude Code to assist with the final edits, as adding Union to the function signature return type alone wasn't sufficient.

## Changes Made
<!-- List the main changes made in this PR -->

Resolved 5 static type checking errors flagged by mypy:

In categorical_colours, duo_colours, sequential_colours, and focus_colours: added explicit type annotations to local variables that are assigned in conditional branches. Mypy inferred the type from the hex branch alone and rejected the rgb branch assignment as incompatible. The annotation Union[List[str], List[Tuple[int, int, int]]] tells mypy the variable can hold either type.

In hex_to_rgb: replaced tuple(generator) with an explicit tuple literal (int(...), int(...), int(...)). The original form produced tuple[int, ...] (unknown length) which did not satisfy the declared return type of List[Tuple[int, int, int]].

### Related Issues
<!-- Link to related issues using keywords like "Fixes #123", "Closes #456", "Relates to #789" -->
- Relates to #114 
