### PR TITLE
docs: adding instructions on plotly reverting template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,103 @@
+# Code of Conduct for `afcharts-py`
+
+All contributors to this repository hosted by `best-practice-and-impact` are expected to follow the
+Contributor Covenant Code of Conduct. Those working within HM Government are also expected to follow the [Civil Service
+Code][civil-service-code].
+
+## Contributor Covenant Code of Conduct
+
+### Definitions
+
+Where this Code of Conduct says:
+
+- "Project", we mean this GitHub repository, `afcharts-py` ;
+- "Maintainer", we mean active developers of `afcharts-py`; and
+- "Leadership", we mean `best-practice-and-impact` organisation owners, line managers, and other leadership within the Office for National Statistics.
+
+### Our Pledge
+We as members, contributors, and leaders pledge to make participation
+in our community a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+### Encouraged behaviours
+While acknowledging differences in social norms, we all strive to meet our community’s expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+- Respecting the purpose of our community, our activities, and our ways of gathering.
+- Engaging kindly and honestly with others.
+- Respecting different viewpoints and experiences.
+- Taking responsibility for our actions and contributions.
+- Gracefully giving and accepting constructive feedback.
+- Committing to repairing harm when it occurs.
+- Behaving in other ways that promote and sustain the well-being of our community.
+
+### Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+- Harassment. Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+- Character attacks. Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+- Stereotyping or discrimination. Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+- Sexualization. Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+- Violating confidentiality. Sharing or acting on someone’s personal or private information without their permission.
+- Endangerment. Causing, encouraging, or threatening violence or other harm toward any person or group.
+- Behaving in other ways that threaten the well-being of our community.
+
+### Other Restrictions
+
+- Misleading identity. Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+- Failing to credit sources. Not properly crediting the sources of content you contribute.
+- Promotional materials. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+- Irresponsible communication. Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+### Our Responsibilities
+
+Project maintainers are expected to raise any instances of unacceptable behaviour to
+project leadership.
+
+Project leadership are responsible for clarifying the standards of acceptable
+behaviour. They also have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct, or to ban temporarily or permanently any contributor
+for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an
+individual is representing the project or its community in public spaces. Examples of
+representing a project or community include using an official project e-mail address,
+posting using an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project leadership.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by
+contacting the project team at ASAP@ons.gov.uk. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by members of the
+project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][contributor-covenant],
+version [3.0][contributor-covenant-code-of-conduct],
+and the `govcookiecutter` Code of Conduct available at
+[https://github.com/best-practice-and-impact/govcookiecutter/blob/main/CODE_OF_CONDUCT.md][govcookiecutter-code-of-conduct].
+
+[govcookiecutter-code-of-conduct]: https://github.com/best-practice-and-impact/govcookiecutter/blob/main/CODE_OF_CONDUCT.md
+[civil-service-code]: https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code
+[contributor-covenant]: https://www.contributor-covenant.org
+[contributor-covenant-code-of-conduct]: https://www.contributor-covenant.org/version/3/0/code_of_conduct/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ maintainers = [
     { name = "Stelios Georgiou", email = "Stelios.Georgiou@ukhsa.gov.uk" },
     { name = "Frederico Rodrigues", email = "fred.rodrigues@defra.gov.uk" },
     { name = "Peter Brohan", email = "peter.brohan@communities.gov.uk"},
-    { name = "Fahim Hossain", email = "fahim.hossain@ukhsa.gov.uk"}
+    { name = "Fahim Hossain", email = "fahim.hossain@ukhsa.gov.uk"},
+    { name = "Craig Miles-Clarke", email = "craig.miles-clarke@oxfordshire.gov.uk"}
     # Other contributors, please add your details here
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,12 @@ test = [ # package unit testing dependencies
     "pytest-sugar>=1.0.0", # Prettier pytest terminal output
 ]
 docs = [ # cookbook dependencies
+    "geopandas",         # For chloropleth map in plotly examples
     "ipykernel",         # For rendering Quarto
     "nbclient",          # For rendering Quarto
     "pandas>=2.2.2",     # Used to manipulate tabular data
+    "requests",
+    "openpyxl",          # For reading/writing Excel files
 ]
 
 [project.urls]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,0 @@
-{
-  "packages": {
-    ".": {
-      "release-type": "python",
-      "bump-minor-pre-major": true
-    }
-  }
-}

--- a/src/afcharts/af_colours.py
+++ b/src/afcharts/af_colours.py
@@ -4,16 +4,27 @@
 # Py-af-colours source: https://github.com/best-practice-and-impact/py-af-colours
 
 from pathlib import Path
+from typing import List, Literal
 
 import yaml
 
+ColourFormat = Literal["hex", "rgb"]
+PaletteName = Literal["duo", "focus", "categorical", "sequential"]
 
-def get_af_colours(palette: str, colour_format="hex", number_of_colours=6, config_path=None):
+
+def get_af_colours(
+    palette: PaletteName,
+    colour_format: ColourFormat = "hex",
+    number_of_colours: int | None = None,
+    config_path: str | Path | None = None,
+    include_grey: bool = False,
+) -> List:
     """
     get_af_colours() is the top level function in af_colours. This returns
     the chosen Analysis Function colour palette in hex or rgb format.
     For the categorical palette, this can be a chosen number of colours
-    up to 6.
+    up to 6. For the sequential palette, this can be a chosen number of colours of 3,
+    4, or 5.
 
     Parameters
     ----------
@@ -25,12 +36,17 @@ def get_af_colours(palette: str, colour_format="hex", number_of_colours=6, confi
         Colour format required, with accepted values of "hex" or "rgb".
 
     number_of_colours : int, optional
-        Number of colours required (categorical palette only). Takes
-        values between 2 and 6. Returns 2 colours by default. If a
-        palette other than categorical is chosen, any value passed
-        is ignored.
+        Number of colours required. For the sequential palette, takes
+        values 3, 4, or 5 (applying guidance-informed subsets). For categorical
+        palette, takes values between 2 and 6. The default is None, which uses the
+        default value for the chosen colour palette.
+        If palette is another type, this argument is ignored.
 
-    config_path : NoneType, optional
+    include_grey : bool, optional
+        Whether to include the grey colour in the sequential palette. Can be used to show
+        null values in charts. The default is False, which excludes the grey colour.
+
+    config_path : str | Path | None, optional
         Takes the default value None, inside the function this is
         mapped to the relative path independent of operating system.
         Should not require changing.
@@ -54,35 +70,44 @@ def get_af_colours(palette: str, colour_format="hex", number_of_colours=6, confi
     with open(config_path) as file:
         config = yaml.load(file, Loader=yaml.BaseLoader)
 
-    categorical_hex_list = config["categorical_hex_list"]
-    duo_hex_list = config["duo_hex_list"]
-    sequential_hex_list = config["sequential_hex_list"]
-    focus_hex_list = config["focus_hex_list"]
+    categorical_hex_list: List[str] = config["categorical_hex_list"]
+    duo_hex_list: List[str] = config["duo_hex_list"]
+    sequential_hex_list: List[str] = config["sequential_hex_list"]
+    focus_hex_list: List[str] = config["focus_hex_list"]
 
     if palette not in ["categorical", "duo", "sequential", "focus"]:
         raise ValueError("palette must be one of 'categorical', 'duo', 'sequential' " + f"or 'focus', not {palette}.")
+
     if colour_format not in ["hex", "rgb"]:
         raise ValueError(f"colour_format must be 'hex' or 'rgb', not {colour_format}.")
 
-    if number_of_colours < 1:
+    if number_of_colours is not None and number_of_colours < 1:
         raise ValueError("number_of_colours must be greater than 0.")
 
-    elif palette == "sequential":
-        chosen_colours_list = sequential_colours(sequential_hex_list, colour_format)
+    if palette == "sequential":
+        return sequential_colours(
+            sequential_hex_list,
+            colour_format=colour_format,
+            number_of_colours=number_of_colours or 5,
+            include_grey=include_grey,
+        )
 
-    elif palette == "focus":
-        chosen_colours_list = focus_colours(focus_hex_list, colour_format)
+    if palette == "focus":
+        return focus_colours(focus_hex_list, colour_format)
 
-    elif palette == "duo":
-        chosen_colours_list = duo_colours(duo_hex_list, colour_format)
+    if palette == "duo":
+        return duo_colours(duo_hex_list, colour_format)
 
-    elif palette == "categorical":
-        chosen_colours_list = categorical_colours(categorical_hex_list, duo_hex_list, colour_format, number_of_colours)
-
-    return chosen_colours_list
+    # palette == "categorical"
+    return categorical_colours(categorical_hex_list, duo_hex_list, colour_format, number_of_colours)
 
 
-def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex", number_of_colours=2):
+def categorical_colours(
+    categorical_hex_list: List[str],
+    duo_hex_list: List[str],
+    colour_format: ColourFormat = "hex",
+    number_of_colours: int | None = 6,
+) -> List:
     """
     Return the Analysis Function categorical colour palette as a list
     in hex or rgb format for up to 6 colours. If number_of_colours is
@@ -102,7 +127,7 @@ def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex",
 
     number_of_colours : int
         Number of colours required, with accepted values between 2 and 6
-        inclusive. Returns 2 colours if no value given.
+        inclusive. Returns 6 colours if no value given.
 
     Raises
     ------
@@ -115,15 +140,17 @@ def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex",
         categorical_colours_list
 
     """
+    n = 6 if number_of_colours is None else number_of_colours
 
-    if number_of_colours > 6:
+    if n > 6:
         raise ValueError("number_of_colours must not be more than 6 for the categorical palette.")
+    if n < 2:
+        raise ValueError("number_of_colours must be at least 2 for the categorical palette.")
 
-    if number_of_colours == 2:
-        categorical_colours_list = duo_colours(duo_hex_list, colour_format)
-        return categorical_colours_list
+    if n == 2:
+        return duo_colours(duo_hex_list, colour_format)
 
-    elif colour_format == "hex":
+    if colour_format == "hex":
         full_categorical_colours_list = categorical_hex_list
 
     elif colour_format == "rgb":
@@ -132,16 +159,13 @@ def categorical_colours(categorical_hex_list, duo_hex_list, colour_format="hex",
     else:
         raise ValueError(f"colour_format must be 'hex' or 'rgb', not {colour_format}.")
 
-    categorical_colours_list = full_categorical_colours_list[0:number_of_colours]
-
-    return categorical_colours_list
+    return full_categorical_colours_list[0:n]
 
 
-def duo_colours(duo_hex_list, colour_format="hex"):
+def duo_colours(duo_hex_list: List[str], colour_format: ColourFormat = "hex") -> List:
     """
     Return the Analysis Function duo colour palette as a list of 2
-    colours in hex or rgb format. This function is also called by
-    sequential_colours() if number_of_colours is equal to 2.
+    colours in hex or rgb format.
 
     Parameters
     ----------
@@ -158,21 +182,24 @@ def duo_colours(duo_hex_list, colour_format="hex"):
         duo_colours_list
 
     """
-
     if colour_format == "hex":
-        duo_colours_list = duo_hex_list
+        return duo_hex_list
     elif colour_format == "rgb":
-        duo_colours_list = hex_to_rgb(duo_hex_list)
+        return hex_to_rgb(duo_hex_list)
     else:
         raise ValueError(f"colour_format must be 'hex' or 'rgb', not {colour_format}.")
 
-    return duo_colours_list
 
-
-def sequential_colours(sequential_hex_list, colour_format="hex"):
+def sequential_colours(
+    sequential_hex_list: List[str],
+    colour_format: ColourFormat = "hex",
+    number_of_colours: int = 5,
+    include_grey: bool = False,
+) -> List:
     """
     Return the Analysis Function sequential colour palette as a list
-    of 3 colours in hex or rgb format.
+    in hex or rgb format. Supports combinations of 3, 4, or 5 colours
+    based on Analysis Function guidance.
 
     Parameters
     ----------
@@ -182,24 +209,43 @@ def sequential_colours(sequential_hex_list, colour_format="hex"):
     colour_format : string
         Colour format required, with accepted values of "hex" or "rgb".
 
+    number_of_colours: int
+        Number of sequential colours required, with accepted values of 3,
+        4, or 5. Defaults to 5.
+
+    include_grey : bool, optional
+        Whether to include the grey colour in the palette. Can be used to show
+        null values in charts. The default is False, which excludes the grey colour.
+
     Returns
     -------
     list
         sequential_colours_list
 
     """
+    SEQUENTIAL_COMBOS = {
+        3: [sequential_hex_list[1], sequential_hex_list[2], sequential_hex_list[3]],
+        4: [sequential_hex_list[0], sequential_hex_list[1], sequential_hex_list[2], sequential_hex_list[3]],
+        5: sequential_hex_list[:5],
+    }
+
+    if number_of_colours not in [3, 4, 5]:
+        raise ValueError("number_of_colours must be 3, 4, or 5 for the sequential palette.")
+
+    if include_grey:
+        colours = SEQUENTIAL_COMBOS[number_of_colours] + [sequential_hex_list[-1]]
+    else:
+        colours = SEQUENTIAL_COMBOS[number_of_colours]
 
     if colour_format == "hex":
-        sequential_colours_list = sequential_hex_list
+        return colours
     elif colour_format == "rgb":
-        sequential_colours_list = hex_to_rgb(sequential_hex_list)
+        return hex_to_rgb(colours)
     else:
         raise ValueError(f"colour_format must be 'hex' or 'rgb', not {colour_format}.")
 
-    return sequential_colours_list
 
-
-def focus_colours(focus_hex_list, colour_format="hex"):
+def focus_colours(focus_hex_list: List[str], colour_format: ColourFormat = "hex") -> List:
     """
     Return the Analysis Function focus colour palette as a list of 2
     colours in hex or rgb format.
@@ -220,16 +266,14 @@ def focus_colours(focus_hex_list, colour_format="hex"):
     """
 
     if colour_format == "hex":
-        focus_colours_list = focus_hex_list
+        return focus_hex_list
     elif colour_format == "rgb":
-        focus_colours_list = hex_to_rgb(focus_hex_list)
+        return hex_to_rgb(focus_hex_list)
     else:
         raise ValueError(f"colour_format must be 'hex' or 'rgb', not {colour_format}.")
 
-    return focus_colours_list
 
-
-def hex_to_rgb(hex_colours):
+def hex_to_rgb(hex_colours: List[str]) -> List:
     """
     Convert a list of hex codes to a list of rgb colours.
 
@@ -247,13 +291,17 @@ def hex_to_rgb(hex_colours):
     Returns
     -------
     list
-        converted_list
+        rgb_list
 
     """
     if type(hex_colours) is not list:
         raise TypeError("hex_colours must be a list.")
 
+    for value in hex_colours:
+        if not isinstance(value, str):
+            raise TypeError("hex_colours must be a list of hex strings.")
+
     hex_colours_new = [i.lstrip("#") for i in hex_colours]
 
-    converted_list = [(tuple(int(value[i : i + 2], 16) for i in (0, 2, 4))) for value in hex_colours_new]
-    return converted_list
+    rgb_list = [(tuple(int(value[i : i + 2], 16) for i in (0, 2, 4))) for value in hex_colours_new]
+    return rgb_list

--- a/src/afcharts/afcharts.mplstyle
+++ b/src/afcharts/afcharts.mplstyle
@@ -38,5 +38,3 @@ ytick.direction : out
 # LEGEND
 legend.frameon : False
 
-# FIGURE OUTPUT 
-figure.figsize : 6.4, 4.8

--- a/src/afcharts/config/af_colours.yaml
+++ b/src/afcharts/config/af_colours.yaml
@@ -1,4 +1,4 @@
 categorical_hex_list: ["#12436D","#28A197","#801650", "#F46A25","#3D3D3D","#A285D1"]
 duo_hex_list: ["#12436D","#F46A25"]
-sequential_hex_list: ["#12436D", "#2073BC", "#6BACE6"]
+sequential_hex_list: ["#092135", "#12436D", "#2073BC", "#6BACE6", "#ADD1F1", "#F2F2F2"]
 focus_hex_list: ["#12436D","#BFBFBF"]

--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -597,6 +597,60 @@ fig
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
 </div>
 
+## Annotations
+
+Labelling your chart is often preferable to using a legend, as often this relies on a user matching the legend to the data using colour alone.
+
+You can add an annotation anywhere on a chart using the `annotate()` method. This is demonstrated above in [Line chart with duo palette](#line-chart-with-duo-palette), which directly labels each line. Note that black text has been used for the labels, as this ensures sufficient contrast against the white background.
+
+To add value labels to bars in a bar chart, use the `bar_label()` method. In the example below, the population values are added as white text labels inside the bars.
+
+```{python}
+#| output: false
+import matplotlib.pyplot as plt
+
+# Load gapminder dataset from plotly
+from plotly.express.data import gapminder
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+# Filter for Americas in 2007 and get top 5 by population
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+
+top5 = df.nlargest(5, "pop")
+
+fig, ax = plt.subplots()
+
+bars = ax.bar(
+    top5["country"],
+    top5["pop"] / 1e6,  # Convert to millions
+)
+
+# Add text annotations to top of each bar
+ax.bar_label(bars, labels=[f'{round(val, 1)}' for val in top5["pop"] / 1e6],
+             color='white', padding=-15)
+
+fig
+```
+
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="barchart-annotated-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="barchart-annotated-desc">
+This bar chart uses the afcharts theme, and shows the populations of the five most populous countries in the Americas. Each bar is dark blue and labelled by country underneath. White text labels are added inside each bar showing the population value in millions. Pale grey grid lines extend out from the y axis.
+</div>
+
 ## Other customisations
 ### Sorting a bar chart
 

--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -292,8 +292,51 @@ fig
 </div>
 <div class="chart-source">Source: Gapminder</div>
 <div class="chart-alt" id="barchart-stack-desc">
-This histogram uses the afcharts theme, and shows the distribution of life expectancy by number of countries. There are pale grey grid lines extending out from the y axis. The bars are dark blue with white space between each.
+This stacked bar chart uses the afcharts theme and shows the proportions of countries with a life expectancy over and under 75 by continent. The continents are listed along the x axis, with the y axis labelled between 0% and 100%. The colours for the bar segments are from the main Analysis Function palette - dark blue for under 75 and orange for over 75, denoted by a legend at the bottom of the chart. There is whitespace between each bar.
 </div>
+
+
+## Histograms
+
+```{python}
+
+#| output: false
+import matplotlib.pyplot as plt
+from plotly.express.data import gapminder
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+# Filter for year 2007
+df = gapminder().query("year == 2007")
+
+fig = plt.figure()
+
+plt.hist(
+    df["lifeExp"],
+    bins=range(int(df["lifeExp"].min()), int(df["lifeExp"].max()) + 5, 5),
+    edgecolor="white"
+)
+
+plt.ylabel("Number of\n countries", rotation=0, labelpad=40)
+
+fig
+```
+
+<div class="chart-title">How life expectancy varies</div>
+<div class="chart-subtitle">Distribution of life expectancy, 2007</div>
+<div class="chart" aria-describedby="histogram-1-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div> 
+<div class="chart-source">Source: Gapminder</div>
+ <div class="chart-alt" id="histogram-1-desc"> This histogram uses the afcharts theme, and shows the distribution of life expectancy across countries in 2007. The x-axis shows life expectancy in 5-year bins, and the y-axis shows the number of countries. The bars are dark blue with white edges separating each bin. Pale grey grid lines extend out from the y-axis. </div>
 
 ## Scatterplots
 

--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -4,14 +4,15 @@
 ### Single line chart
 
 ```{python}
-#| output: false
-import matplotlib.pyplot as plt
+# | output: false
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
+import matplotlib.pyplot as plt
 
 # Set default theme
 plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 df = gapminder().query("country == 'United Kingdom'")
 
@@ -46,7 +47,8 @@ This line chart uses the afcharts theme. There are pale grey grid lines extendin
 ### Line chart with duo palette
 
 ```{python}
-#| output: false
+# | output: false
+
 import matplotlib.pyplot as plt
 
 from afcharts.af_colours import get_af_colours
@@ -54,11 +56,11 @@ from afcharts.af_colours import get_af_colours
 # Get the duo colour palette
 duo = get_af_colours("duo")
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
-
 # Set default theme
 plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 df = gapminder()
 df = df[df["country"].isin(["United Kingdom", "China"])]
@@ -71,10 +73,10 @@ for i, (country, data) in enumerate(df.groupby("country")):
     ax.annotate(
         country,
         xy=(data["year"].values[-1], data["lifeExp"].values[-1]),
-        xytext=(6,0),
+        xytext=(6, 0),
         textcoords="offset points",
-        bbox=dict(boxstyle="square", fc="white", lw=0)  # Add a white background
-        )
+        bbox=dict(boxstyle="square", fc="white", lw=0),  # Add a white background
+    )
 
 plt.xlim([1950, 2010])
 plt.ylim([0, 82])
@@ -95,8 +97,8 @@ fig
 
 </div>
 <div class="chart-source">Source: Gapminder</div>
-<div class="chart-alt" id = "linechart-2-desc">
-This line chart uses the afcharts theme and there are thin pale grey lines extending from the y axis. There are two thicker lines showing the life expectancy in the UK and China over time. The line colours are from the main Analysis Function palette - dark blue for China and orange for the UK, denoted by a legend at the bottom of the chart.
+<div class="chart-alt" id="linechart-2-desc">
+This line chart uses the afcharts theme and there are thin pale grey lines extending from the y axis. There are two thicker lines showing the life expectancy in the UK and China over time. The line colours are from the Analysis Function 'duo' palette - dark blue for China and orange for the UK, denoted by a legend at the bottom of the chart.
 </div>
 
 <!--This differs from the plotly page. Update when legends are removed-->
@@ -105,13 +107,14 @@ This line chart uses the afcharts theme and there are thin pale grey lines exten
 
 ```{python}
 # | output: false
-import matplotlib.pyplot as plt
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
+import matplotlib.pyplot as plt
 
 # Set default theme
 plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 # Filter for Americas in 2007 and get top 5 by population
 df = gapminder().query("year == 2007 & continent == 'Americas'")
@@ -148,39 +151,41 @@ This bar chart uses the afcharts theme, and shows the populations of the five mo
 ### Grouped bar chart
 
 ```{python}
-#| output: false
+# | output: false
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
-
 from afcharts.af_colours import get_af_colours
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
 
 # Get the duo colour palette
 duo = get_af_colours("duo")
 
-# Set default theme
-plt.style.use("afcharts.afcharts")
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
-# Load gapminder data from plotly
-df = gapminder().query("year in [1967, 2007] and country in ['United Kingdom', 'Ireland', 'France', 'Belgium']")
+df = gapminder().query(
+    "year in [1967, 2007] & country in ['United Kingdom', 'Ireland', 'France', 'Belgium']"
+)
 
-countries = ['United Kingdom', 'Ireland', 'France', 'Belgium']
+countries = ["United Kingdom", "Ireland", "France", "Belgium"]
 years = [1967, 2007]
 bar_width = 0.35
 x = np.arange(len(countries))
 
 fig = plt.figure()
 
-for i, year in enumerate(years):
-    data = df[df["year"] == year].set_index("country").reindex(countries)
+for i, year in enumerate(sorted(df["year"].unique())):
+    df_year = df[df["year"] == year].set_index("country").reindex(countries)
     plt.bar(
         x + i * bar_width,
-        data["lifeExp"],
+        df_year["lifeExp"],
         width=bar_width,
         label=str(year),
-        color=duo[i]
+        color=duo[i % len(duo)]
     )
 plt.xticks(x + bar_width / 2, countries)
 plt.legend(
@@ -188,13 +193,12 @@ plt.legend(
     bbox_to_anchor=(0.5, -0.25),
     ncol=2
 )
-
 fig
 ```
 
 <div class="chart-title">Living longer</div>
 <div class="chart-subtitle">Life expectancy (years) in 1967 and 2007</div>
-<div class ="chart" aria-describedby="barchart-2-desc">
+<div class="chart" aria-describedby="barchart-2-desc">
 
 ```{python}
 #| echo: false
@@ -205,8 +209,8 @@ fig
 
 </div>
 <div class="chart-source">Source: Gapminder</div>
-<div class="chart-alt" id="bartchart-2-desc">
-This grouped bar chart uses the afcharts theme. It shows the life expectancy in 1967 and 2007 for four countries, which are displayed on the x axis. For each country there are two bars. The bar colours are from the main Analysis Function palette - dark blue for 1967 and orange for 2007, denoted by a legend at the bottom of the chart.
+<div class="chart-alt" id="barchart-2-desc">
+This grouped bar chart uses the afcharts theme. It shows the life expectancy in 1967 and 2007 for four countries, which are displayed on the x axis. For each country there are two bars. The bar colours are from the Analysis Function 'duo' palette - dark blue for 1967 and orange for 2007, denoted by a legend at the bottom of the chart.
 </div>
 
 ### Stacked bar chart
@@ -216,13 +220,11 @@ Caution should be taken when producing stacked bar charts. They can quickly beco
 ```{python}
 # | eval: true
 # | output: false
+
+import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mtick
 import numpy as np
-
-from pandas import cut
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
 
 from afcharts.af_colours import get_af_colours
 
@@ -233,12 +235,14 @@ duo = get_af_colours("duo")
 plt.style.use("afcharts.afcharts")
 
 # Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
 df = gapminder().query("year == 2007")
 
 # Create life expectancy groups
-df['lifeExpGrouped'] = cut(
-    df['lifeExp'],
-    bins=[0, 75, float('inf')],
+df["lifeExpGrouped"] = pd.cut(
+    df["lifeExp"],
+    bins=[0, 75, float("inf")],
     labels=["Under 75", "75 and over"]
 )
 
@@ -263,11 +267,14 @@ fig = plt.figure(figsize=(8, 5))
 
 bottom = np.zeros(len(pivot_df))
 for i, category in enumerate(categories):
+    percent_col = f"percent of {category}"
+    life_exp_data = pivot_df[[percent_col]]
+
     plt.bar(
-        pivot_df.index,
-        pivot_df[f"percent of {category}"],
-        label=category,
-        color=duo[i],
+        life_exp_data.index,
+        life_exp_data[percent_col],
+        label=str(category),
+        color=duo[i % len(duo)],
         bottom=bottom,
     )
     bottom += pivot_df[f"percent of {category}"]
@@ -292,7 +299,7 @@ fig
 </div>
 <div class="chart-source">Source: Gapminder</div>
 <div class="chart-alt" id="barchart-stack-desc">
-This stacked bar chart uses the afcharts theme and shows the proportions of countries with a life expectancy over and under 75 by continent. The continents are listed along the x axis, with the y axis labelled between 0% and 100%. The colours for the bar segments are from the main Analysis Function palette - dark blue for under 75 and orange for over 75, denoted by a legend at the bottom of the chart. There is whitespace between each bar.
+This stacked bar chart uses the afcharts theme and shows the proportions of countries with a life expectancy over and under 75 by continent. The continents are listed along the x axis, with the y axis labelled between 0% and 100%. The colours for the bar segments are from the Analysis Function 'duo' palette - dark blue for under 75 and orange for over 75, denoted by a legend at the bottom of the chart. There is whitespace between each bar.
 </div>
 
 
@@ -300,12 +307,15 @@ This stacked bar chart uses the afcharts theme and shows the proportions of coun
 
 ```{python}
 
-#| output: false
+# | output: false
+
 import matplotlib.pyplot as plt
-from plotly.express.data import gapminder
 
 # Set default theme
 plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 # Filter for year 2007
 df = gapminder().query("year == 2007")
@@ -334,9 +344,9 @@ fig
 
 ```
 
-</div> 
+</div>
 <div class="chart-source">Source: Gapminder</div>
- <div class="chart-alt" id="histogram-1-desc"> This histogram uses the afcharts theme, and shows the distribution of life expectancy across countries in 2007. The x-axis shows life expectancy in 5-year bins, and the y-axis shows the number of countries. The bars are dark blue with white edges separating each bin. Pale grey grid lines extend out from the y-axis. </div>
+<div class="chart-alt" id="histogram-1-desc"> This histogram uses the afcharts theme, and shows the distribution of life expectancy across countries in 2007. The x-axis shows life expectancy in 5-year bins, and the y-axis shows the number of countries. The bars are dark blue with white edges separating each bin. Pale grey grid lines extend out from the y-axis. </div>
 
 ## Scatterplots
 
@@ -346,13 +356,12 @@ fig
 import matplotlib.pyplot as plt
 from matplotlib.ticker import StrMethodFormatter
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
-
 # Set default theme
 plt.style.use("afcharts.afcharts")
 
 # Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
 df = gapminder().query("year == 2007")
 
 # Make the figure wider than the default (6.4, 4.8)
@@ -360,7 +369,7 @@ fig = plt.figure(figsize=(8.5, 4.8))
 
 plt.scatter(df["gdpPercap"], df["lifeExp"])
 
-# Set axis limits to start at 0
+# Axes should start from 0
 plt.xlim(0, 5e4)
 plt.ylim(0, max(df["lifeExp"]) + 5)
 plt.xlabel("GDP per capita ($US, inflation-adjusted)")
@@ -400,9 +409,6 @@ This scatterplot uses the afcharts theme, and shows life expectancy against GDP 
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
-
 from afcharts.af_colours import get_af_colours
 
 # Get the categorical colour palette
@@ -411,13 +417,15 @@ categorical = get_af_colours("categorical")
 # Set default theme
 plt.style.use("afcharts.afcharts")
 
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
 df = gapminder()
 
 # Filter out Oceania and aggregate population by continent and year
 df_grouped = (
     df[df["continent"] != "Oceania"]
-    .groupby(["continent", "year"], observed=True)["pop"]
-    .sum()
+    .groupby(["continent", "year"], observed=True)["pop"].sum()
     .reset_index()
 )
 
@@ -428,7 +436,6 @@ continents = df_grouped["continent"].unique()
 fig, axes = plt.subplots(
     ncols=2, nrows=2, sharex=True, sharey=True, constrained_layout=True
 )
-
 
 # Make custom formatter for tick labels
 def tick_billions(x, pos):
@@ -466,17 +473,13 @@ This chart uses the afcharts theme. It contains four subplots in a two by two gr
 </div>
 
 ## Pie charts
-
 ```{python}
 # | eval: true
 # | output: false
 
+import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
-from pandas import cut
-
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
 
 from afcharts.af_colours import get_af_colours
 
@@ -486,12 +489,15 @@ duo = get_af_colours("duo")
 # Set default theme
 plt.style.use("afcharts.afcharts")
 
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
 df = gapminder().query("continent == 'Europe' and year == 2007")
 
 # Create life expectancy groups
-df['lifeExpGrouped'] = cut(
-    df['lifeExp'],
-    bins=[0, 75, float('inf')],
+df["lifeExpGrouped"] = pd.cut(
+    df["lifeExp"],
+    bins=[0, 75, float("inf")],
     labels=["Under 75", "75 and over"]
 )
 
@@ -540,9 +546,6 @@ This pie chart uses the afcharts theme, showing the proportions of European coun
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
-
 from afcharts.af_colours import get_af_colours
 
 # Get the focus colour palette
@@ -550,6 +553,9 @@ focus = get_af_colours("focus")
 
 # Set default theme
 plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 df = gapminder().query("year == 2007 & continent == 'Americas'")
 
@@ -560,11 +566,15 @@ colours = {
     for country in top5["country"].unique()
 }
 
+# Map colors to bar order
+bar_colours = [colours[country] for country in top5["country"]]
+
 fig = plt.figure(figsize=(8, 5))
+
 plt.bar(
     top5["country"],
     top5["pop"] / 1e6,
-    color=[colours[country] for country in top5["country"]],
+    color=bar_colours,
 )
 
 fig
@@ -594,14 +604,15 @@ To control the order of bars in a bar chart, sort the data object before plottin
 
 
 ```{python}
-#| output: false
-import matplotlib.pyplot as plt
+# | output: false
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
+import matplotlib.pyplot as plt
 
 # Set default theme
 plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 # Filter for Americas in 2007 and get top 5 by population
 df = gapminder().query("year == 2007 & continent == 'Americas'")
@@ -639,14 +650,14 @@ This bar chart uses the afcharts theme, and shows the populations of the five mo
 To add a horizontal or vertical line across the whole plot, use `axhline()` or `axvline()` respectively. Annotating the line can be achieved using `text()`. This can be useful to highlight a threshold or average level.  
 
 ```{python}
-#| output: false
-import matplotlib.pyplot as plt
+# | output: false
 
-# Load gapminder dataset from plotly
-from plotly.express.data import gapminder
+import matplotlib.pyplot as plt
 
 # Set default theme
 plt.style.use("afcharts.afcharts")
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
 
 df = gapminder().query("country == 'United Kingdom'")
 
@@ -656,13 +667,14 @@ fig = plt.figure(figsize=(8.5, 4.8))
 plt.plot(df["year"], df["lifeExp"])
 
 # Add a dotted horizontal line for 70 years of age
-plt.axhline(y=70, linestyle='--', color='gray', linewidth=2)
-plt.text(2005, 71, 'Age 70', fontsize=10, fontweight='normal', color='black')
+plt.axhline(y=70, linestyle="--", color="gray", linewidth=2)
+plt.text(2005, 71, "Age 70", fontsize=12, fontweight="normal", color="black")
 
 plt.xlim([1950, 2010])
 plt.ylim([0, 82])
 
 fig
+
 ```
 
 <div class="chart-title">Living Longer</div>
@@ -689,27 +701,37 @@ If text is too long, it may be cut off or distort the dimensions of the chart. T
 Alternatively, you can manually add line breaks by inserting `\n` into the text string to control where the text is wrapped. See the y-axis label in the figure below for an example.
 
 ```{python}
-#| output: false
+# | output: false
+
 import textwrap
 import matplotlib.pyplot as plt
-from plotly.express.data import gapminder
 
+# Set default theme
 plt.style.use("afcharts.afcharts")
 
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
 df = gapminder().query("year == 2007 & continent == 'Americas'")
+
 top5 = df.nlargest(5, "pop")
 
 fig = plt.figure()
+
 plt.bar(top5["country"], top5["pop"] / 1e6)
 
-plt.title(textwrap.fill(
-    "The U.S.A. is the most populous country in the Americas by a wide margin",
-    width=40,
-))
-plt.ylabel("Population\nin millions", rotation=0, labelpad=40)  
+plt.title(
+    textwrap.fill(
+        "The U.S.A. is the most populous country in the Americas by a wide margin",
+        width=40,
+    )
+)
+plt.ylabel("Population\nin millions", rotation=0, labelpad=40)
 
 fig
+
 ```
+
 <div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
 <div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
 <div class="chart" aria-describedby="textwrap-desc">

--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -583,6 +583,146 @@ fig
 
 </div>
 <div class="chart-source">Source: Gapminder</div>
-<div class="chart-alt">
+<div class="chart-alt" id="focus-desc">
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
+</div>
+
+## Other customisations
+### Sorting a bar chart
+
+To control the order of bars in a bar chart, sort the data object before plotting. For Pandas data frames, you can use the `.sort_values()` method. Pass the name or list of names that you would like to sort by and specify whether ascending (True, default) or descending (False). In this below example, the data is sorted on `pop` and ascending is set to `True` so that the bars are displayed in ascending order of population.
+
+
+```{python}
+#| output: false
+import matplotlib.pyplot as plt
+
+# Load gapminder dataset from plotly
+from plotly.express.data import gapminder
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+# Filter for Americas in 2007 and get top 5 by population
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+
+top5 = df.nlargest(5, "pop").sort_values("pop", ascending=True)
+
+fig = plt.figure(figsize=(8, 5))
+plt.barh(
+    top5["country"],
+    top5["pop"] / 1e6,  # Convert to millions
+)
+
+fig
+```
+
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="sortbar-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="sortbar-desc">
+This bar chart uses the afcharts theme, and shows the populations of the five most populous countries in the Americas, sorted in ascending order by population. Each bar is dark blue and labelled by country underneath. All text is black in a sans serif font. Pale grey grid lines extend out from the y axis.
+</div>
+
+### Adding a horizontal or vertical line
+
+To add a horizontal or vertical line across the whole plot, use `axhline()` or `axvline()` respectively. Annotating the line can be achieved using `text()`. This can be useful to highlight a threshold or average level.  
+
+```{python}
+#| output: false
+import matplotlib.pyplot as plt
+
+# Load gapminder dataset from plotly
+from plotly.express.data import gapminder
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+df = gapminder().query("country == 'United Kingdom'")
+
+# Make the figure wider than the default (6.4, 4.8)
+fig = plt.figure(figsize=(8.5, 4.8))
+
+plt.plot(df["year"], df["lifeExp"])
+
+# Add a dotted horizontal line for 70 years of age
+plt.axhline(y=70, linestyle='--', color='gray', linewidth=2)
+plt.text(2005, 71, 'Age 70', fontsize=10, fontweight='normal', color='black')
+
+plt.xlim([1950, 2010])
+plt.ylim([0, 82])
+
+fig
+```
+
+<div class="chart-title">Living Longer</div>
+<div class="chart-subtitle">Life expectancy in the United Kingdom 1952 to 2007</div>
+<div class="chart" aria-describedby="hline-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="hline-desc">
+This line chart uses the afcharts theme. There are pale grey grid lines extending from the y axis, and there is a thicker dark blue line representing the data. A dotted horizontal line has been added at 70 years of age, with an annotation to label it.
+</div>
+
+### Wrapping text
+
+If text is too long, it may be cut off or distort the dimensions of the chart. To avoid this, text can be wrapped to multiple lines using the `textwrap` module. The width argument controls how many characters are allowed on each line before wrapping. See the figure title below for an example.
+
+Alternatively, you can manually add line breaks by inserting `\n` into the text string to control where the text is wrapped. See the y-axis label in the figure below for an example.
+
+```{python}
+#| output: false
+import textwrap
+import matplotlib.pyplot as plt
+from plotly.express.data import gapminder
+
+plt.style.use("afcharts.afcharts")
+
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+top5 = df.nlargest(5, "pop")
+
+fig = plt.figure()
+plt.bar(top5["country"], top5["pop"] / 1e6)
+
+plt.title(textwrap.fill(
+    "The U.S.A. is the most populous country in the Americas by a wide margin",
+    width=40,
+))
+plt.ylabel("Population\nin millions", rotation=0, labelpad=40)  
+
+fig
+```
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="textwrap-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="textwrap-desc">
+In this bar chart image, the y-axis label and chart title text have been wrapped onto two lines so that all the text is visible without being cut off.
 </div>

--- a/src/afcharts/cookbook/01-matplotlib-usage.qmd
+++ b/src/afcharts/cookbook/01-matplotlib-usage.qmd
@@ -748,6 +748,12 @@ fig
 This line chart uses the afcharts theme. There are pale grey grid lines extending from the y axis, and there is a thicker dark blue line representing the data. A dotted horizontal line has been added at 70 years of age, with an annotation to label it.
 </div>
 
+### Saving figures
+
+The afcharts style uses a larger base font size (14pt vs Matplotlib's default 10pt) for accessibility. The `figure.figsize` parameter is intentionally not set in the style sheet — the default canvas remains 6.4 × 4.8 inches.
+
+By default, `savefig` saves at exactly `figure.figsize`. If you pass `bbox_inches='tight'`, the output is cropped to the bounding box of all content, so dimensions will vary between charts. Avoid this if you need a consistent, fixed output size.
+
 ### Wrapping text
 
 If text is too long, it may be cut off or distort the dimensions of the chart. To avoid this, text can be wrapped to multiple lines using the `textwrap` module. The width argument controls how many characters are allowed on each line before wrapping. See the figure title below for an example.

--- a/src/afcharts/cookbook/03-plotly-usage.qmd
+++ b/src/afcharts/cookbook/03-plotly-usage.qmd
@@ -9,7 +9,6 @@
 # | eval: true
 # | output: false
 
-import plotly.express as px
 import plotly.graph_objects as go
 
 from afcharts.pio_template import pio
@@ -18,8 +17,9 @@ from afcharts.pio_template import pio
 pio.templates.default = "afcharts"
 
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder()
-df = df[df["country"] == "United Kingdom"]
+from plotly.express.data import gapminder
+
+df = gapminder().query("country == 'United Kingdom'")
 
 # Create figure
 fig = go.Figure()
@@ -60,7 +60,7 @@ fig.show()
 ```
 
 <div class="chart-title">Living Longer</div>
-<div class="chart-subtitle">Life Expectancy in the United Kingdom 1952-2007</div>
+<div class="chart-subtitle">Life expectancy in the United Kingdom 1952 to 2007</div>
 <div class="chart" aria-describedby="linechart-1-desc">
 
 ```{python}
@@ -69,9 +69,10 @@ fig.show()
 fig.show()
 
 ```
+
 </div>
 <div class="chart-source">Source: Gapminder</div>
-<div class="chart-alt" id = "linechart-1-desc">
+<div class="chart-alt" id="linechart-1-desc">
 This line chart uses the afcharts theme. There are pale grey grid lines extending from the y axis, and there is a thicker dark blue line representing the data.
 </div>
 
@@ -88,14 +89,16 @@ import plotly.graph_objects as go
 from afcharts.pio_template import pio
 from afcharts.af_colours import get_af_colours
 
-# Set default theme
-pio.templates.default = "afcharts"
-
 # Get the duo colour palette
 duo = get_af_colours("duo")
 
+# Set default theme
+pio.templates.default = "afcharts"
+
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder()
+from plotly.express.data import gapminder
+
+df = gapminder()
 df = df[df["country"].isin(["United Kingdom", "China"])]
 
 # Create figure
@@ -153,8 +156,8 @@ fig.show()
 ```
 
 <div class="chart-title">Living Longer</div>
-<div class="chart-subtitle">Life Expectancy in the United Kingdom and China 1952-2007</div>
-<div class = "chart" aria-describedby="linechart-2-desc">
+<div class="chart-subtitle">Life expectancy in the United Kingdom and China 1952 to 2007</div>
+<div class="chart" aria-describedby="linechart-2-desc">
 
 ```{python}
 #| echo: false
@@ -166,7 +169,7 @@ fig.show()
 </div>
 <div class="chart-source">Source: Gapminder</div>
 <div class="chart-alt" id="linechart-2-desc">
-This line chart uses the afcharts theme and there are thin pale grey lines extending from the y axis. There are two thicker lines showing the life expectancy in the UK and China over time. The line colours are from the main Analysis Function palette - dark blue for China and orange for the UK, with labels for each line on the right hand side.
+This line chart uses the afcharts theme and there are thin pale grey lines extending from the y axis. There are two thicker lines showing the life expectancy in the UK and China over time. The line colours are from the Analysis Function 'duo' palette - dark blue for China and orange for the UK, with labels for each line on the right hand side.
 </div>
 
 Legends should be avoided unless absolutely necessary, as these usually rely on using colour to match labels to data. More information can be found in the Analysis Function [charts guidance](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-charts/#section-11). It is best practice to label lines directly.
@@ -177,7 +180,6 @@ Legends should be avoided unless absolutely necessary, as these usually rely on 
 # | eval: true
 # | output: false
 
-import plotly.express as px
 import plotly.graph_objects as go
 
 from afcharts.pio_template import pio
@@ -186,16 +188,19 @@ from afcharts.pio_template import pio
 pio.templates.default = "afcharts"
 
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder().query("year == 2007 & continent == 'Americas'")
+from plotly.express.data import gapminder
+
+# Filter for Americas in 2007 and get top 5 by population
+df = gapminder().query("year == 2007 & continent == 'Americas'")
 
 top5 = df.nlargest(5, "pop")
+
 fig = go.Figure()
 
 fig.add_trace(
     go.Bar(
         x=top5["country"],
-        y=top5["pop"]/1e6,  # Convert to millions
-
+        y=top5["pop"] / 1e6,  # Convert to millions
     )
 )
 
@@ -205,6 +210,7 @@ fig.update_layout(
 )
 
 fig.show()
+
 ```
 
 <div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
@@ -230,7 +236,6 @@ This bar chart uses the afcharts theme, and shows the populations of the five mo
 # | eval: true
 # | output: false
 
-import plotly.express as px
 import plotly.graph_objects as go
 
 from afcharts.pio_template import pio
@@ -243,7 +248,9 @@ pio.templates.default = "afcharts"
 duo = get_af_colours("duo")
 
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder().query(
+from plotly.express.data import gapminder
+
+df = gapminder().query(
     "year in [1967, 2007] & country in ['United Kingdom', 'Ireland', 'France', 'Belgium']"
 )
 
@@ -262,7 +269,7 @@ for i, year in enumerate(sorted(df["year"].unique())):
 
 # Update layout
 fig.update_layout(
-    barmode='group',
+    barmode="group",
     height=420,
     legend=dict(
         orientation="h",
@@ -289,8 +296,8 @@ fig.show()
 
 </div>
 <div class="chart-source">Source: Gapminder</div>
-<div class ="chart-alt" id = "barchart-2-desc">
-This grouped bar chart uses the afcharts theme. It shows the life expectancy in 1967 and 2007 for four countries, which are displayed on the x axis. For each country there are two bars. The bar colours are from the main Analysis Function palette - dark blue for 1967 and orange for 2007, denoted by a legend at the bottom of the chart.
+<div class="chart-alt" id="barchart-2-desc">
+This grouped bar chart uses the afcharts theme. It shows the life expectancy in 1967 and 2007 for four countries, which are displayed on the x axis. For each country there are two bars. The bar colours are from the Analysis Function 'duo' palette - dark blue for 1967 and orange for 2007, denoted by a legend at the bottom of the chart.
 </div>
 
 ### Stacked bar chart
@@ -300,26 +307,28 @@ Caution should be taken when producing stacked bar charts. They can quickly beco
 ```{python}
 # | eval: true
 # | output: false
+
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
-
 from afcharts.pio_template import pio
-from afcharts.af_colours import get_af_colours
 
-# Set default theme
-pio.templates.default = "afcharts"
+from afcharts.af_colours import get_af_colours
 
 # Get the duo colour palette
 duo = get_af_colours("duo")
 
+# Set default theme
+pio.templates.default = "afcharts"
+
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder().query("year == 2007")
+from plotly.express.data import gapminder
+
+df = gapminder().query("year == 2007")
 
 # Create life expectancy groups
-df['lifeExpGrouped'] = pd.cut(
-    df['lifeExp'],
-    bins=[0, 75, float('inf')],
+df["lifeExpGrouped"] = pd.cut(
+    df["lifeExp"],
+    bins=[0, 75, float("inf")],
     labels=["Under 75", "75 and over"]
 )
 
@@ -375,8 +384,8 @@ fig.show()
 
 ```
 
-<div class="chart-title">How life expectancy varies</div>
-<div class="chart-subtitle">Distribution of life expectancy, 2007</div>
+<div class="chart-title">How life expectancy varies across continents</div>
+<div class="chart-subtitle">Percentage of countries by life expectancy band, 2007</div>
 <div class="chart" aria-describedby="barchart-stack-desc">
 
 ```{python}
@@ -389,16 +398,16 @@ fig.show()
 </div>
 <div class="chart-source">Source: Gapminder</div>
 <div class="chart-alt" id="barchart-stack-desc">
-This histogram uses the afcharts theme, and shows the distribution of life expectancy by number of countries. There are pale grey grid lines extending out from the y axis. The bars are dark blue with white space between each.
+This stacked bar chart uses the afcharts theme and shows the proportions of countries with a life expectancy over and under 75 by continent. The continents are listed along the x axis, with the y axis labelled between 0% and 100%. The colours for the bar segments are from the Analysis Function 'duo' palette - dark blue for under 75 and orange for over 75, denoted by a legend at the bottom of the chart. There is whitespace between each bar.
 </div>
 
-## Scatterplots
+
+## Histograms
 
 ```{python}
 # | eval: true
 # | output: false
 
-import plotly.express as px
 import plotly.graph_objects as go
 
 from afcharts.pio_template import pio
@@ -407,9 +416,61 @@ from afcharts.pio_template import pio
 pio.templates.default = "afcharts"
 
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder()
+from plotly.express.data import gapminder
 
-df = df.query("year == 2007")
+# Filter for year 2007
+df = gapminder().query("year == 2007")
+
+fig = go.Figure()
+
+fig.add_trace(
+    go.Histogram(
+        x=df["lifeExp"],
+        xbins=dict(start=int(df["lifeExp"].min()), end=int(df["lifeExp"].max()) + 5, size=5),
+    )
+)
+
+# Update layout
+fig.update_layout(
+    height=420,
+    yaxis=dict(title="Number of countries"),
+)
+
+fig.show()
+
+```
+
+<div class="chart-title">How life expectancy varies</div>
+<div class="chart-subtitle">Distribution of life expectancy, 2007</div>
+<div class="chart" aria-describedby="histogram-1-desc">
+
+```{python}
+#| echo: false
+
+fig.show()
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="histogram-1-desc"> This histogram uses the afcharts theme, and shows the distribution of life expectancy across countries in 2007. The x-axis shows life expectancy in 5-year bins, and the y-axis shows the number of countries. The bars are dark blue with white edges separating each bin. Pale grey grid lines extend out from the y-axis. </div>
+
+## Scatterplots
+
+```{python}
+# | eval: true
+# | output: false
+import plotly.graph_objects as go
+
+from afcharts.pio_template import pio
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+df = gapminder().query("year == 2007")
 
 fig = go.Figure()
 
@@ -458,26 +519,29 @@ This scatterplot uses the afcharts theme, and shows life expectancy against GDP 
 # | eval: true
 # | output: false
 
-import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from afcharts.af_colours import get_af_colours
 from afcharts.pio_template import pio
+
+from afcharts.af_colours import get_af_colours
+
+# Get the categorical colour palette
+categorical = get_af_colours("categorical")
 
 # Set default theme
 pio.templates.default = "afcharts"
 
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder()
+from plotly.express.data import gapminder
 
-# Get the categorical colour palette
-categorical = get_af_colours("categorical")
+df = gapminder()
 
 # Filter out Oceania and aggregate population by continent and year
-df_filtered = df[df["continent"] != "Oceania"]
 df_grouped = (
-    df_filtered.groupby(["continent", "year"], observed=True)["pop"].sum().reset_index()
+    df[df["continent"] != "Oceania"]
+    .groupby(["continent", "year"], observed=True)["pop"].sum()
+    .reset_index()
 )
 
 # Define the continents to plot
@@ -519,7 +583,7 @@ fig.update_yaxes(
 fig.update_layout(
     height=550,
     margin=dict(t=30),
-    )
+)
 
 fig.show()
 
@@ -527,6 +591,7 @@ fig.show()
 
 <div class="chart-title">Asia's rapid growth</div>
 <div class="chart-subtitle">Population growth by continent, 1952-2007</div>
+<div class="chart" aria-describedby="small-multiples-desc">
 
 ```{python}
 #| echo: false
@@ -535,9 +600,11 @@ fig.show()
 
 ```
 
+</div>
 <div class="chart-source">Source: Gapminder</div>
-
+<div class="chart-alt" id="small-multiples-desc">
 This chart uses the afcharts theme. It contains four subplots in a two by two grid showing how the populations of four continents have changed over time. Each subplot is labelled with the continent. The subplots have a common y axis, with no values on the x axis to facilitate for a simple comparison of the relative values. Each subplot is filled with a different colour from the Analysis Function categorical colour palette to be distinct from other subplots.
+</div>
 
 ## Pie charts
 ```{python}
@@ -545,25 +612,27 @@ This chart uses the afcharts theme. It contains four subplots in a two by two gr
 # | output: false
 
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 
-from afcharts.af_colours import get_af_colours
 from afcharts.pio_template import pio
 
-# Set default theme
-pio.templates.default = "afcharts"
+from afcharts.af_colours import get_af_colours
 
 # Get the duo colour palette
 duo = get_af_colours("duo")
 
+# Set default theme
+pio.templates.default = "afcharts"
+
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder().query("continent == 'Europe' and year == 2007")
+from plotly.express.data import gapminder
+
+df = gapminder().query("continent == 'Europe' and year == 2007")
 
 # Create life expectancy groups
-df['lifeExpGrouped'] = pd.cut(
-    df['lifeExp'],
-    bins=[0, 75, float('inf')],
+df["lifeExpGrouped"] = pd.cut(
+    df["lifeExp"],
+    bins=[0, 75, float("inf")],
     labels=["Under 75", "75 and over"]
 )
 
@@ -571,15 +640,17 @@ df['lifeExpGrouped'] = pd.cut(
 group_counts = df["lifeExpGrouped"].value_counts().sort_index()
 
 fig = go.Figure(
-    data=[go.Pie(
-        labels=group_counts.index,
-        values=group_counts.values,
-        marker=dict(colors=duo, line=dict(color='white', width=2)),
-        sort=False,
-        textinfo='label+percent',
-        textposition='inside',
-        texttemplate='%{label}<br>(%{percent:.0%})'
-    )]
+    data=[
+        go.Pie(
+            values=group_counts.values,
+            labels=group_counts.index,
+            marker=dict(colors=duo, line=dict(color="white", width=2)),
+            sort=False,
+            textinfo="label+percent",
+            textposition="inside",
+            texttemplate="%{label}<br>(%{percent:.0%})",
+        )
+    ]
 )
 
 # Update layout
@@ -613,11 +684,11 @@ This pie chart uses the afcharts theme, showing the proportions of European coun
 # | eval: true
 # | output: false
 
-import plotly.express as px
 import plotly.graph_objects as go
 
-from afcharts.af_colours import get_af_colours
 from afcharts.pio_template import pio
+
+from afcharts.af_colours import get_af_colours
 
 # Get the focus colour palette
 focus = get_af_colours("focus")
@@ -626,16 +697,19 @@ focus = get_af_colours("focus")
 pio.templates.default = "afcharts"
 
 # Load the gapminder dataset from plotly.express
-df = px.data.gapminder().query("year == 2007 & continent == 'Americas'")
+from plotly.express.data import gapminder
+
+df = gapminder().query("year == 2007 & continent == 'Americas'")
 
 top5 = df.nlargest(5, "pop")
 
-colors = {}
-for country in top5["country"].unique():
-    colors[country] = focus[0] if country == "Brazil" else focus[1]
+colours = {
+    country: focus[0 if country == "Brazil" else 1]
+    for country in top5["country"].unique()
+}
 
 # Map colors to bar order
-bar_colors = [colors[country] for country in top5["country"]]
+bar_colours = [colours[country] for country in top5["country"]]
 
 fig = go.Figure()
 
@@ -643,7 +717,7 @@ fig.add_trace(
     go.Bar(
         x=top5["country"],
         y=top5["pop"],  # Repeat the category name for each x value
-        marker_color=bar_colors,
+        marker_color=bar_colours,
     )
 )
 
@@ -657,6 +731,7 @@ fig.show()
 
 <div class="chart-title">Brazil has the second highest population in the Americas</div>
 <div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="focus-desc">
 
 ```{python}
 #| echo: false
@@ -665,6 +740,215 @@ fig.show()
 
 ```
 
+</div>
 <div class="chart-source">Source: Gapminder</div>
-
+<div class="chart-alt" id="focus-desc">
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
+</div>
+
+## Other customisations
+### Sorting a bar chart
+
+To control the order of bars in a bar chart, sort the data object before plotting. For Pandas data frames, you can use the `.sort_values()` method. Pass the name or list of names that you would like to sort by and specify whether ascending (True, default) or descending (False). In this below example, the data is sorted on `pop` and ascending is set to `True` so that the bars are displayed in ascending order of population.
+
+
+```{python}
+# | output: false
+
+import plotly.graph_objects as go
+
+from afcharts.pio_template import pio
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+# Filter for Americas in 2007 and get top 5 by population
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+
+top5 = df.nlargest(5, "pop").sort_values("pop", ascending=True)
+
+fig = go.Figure()
+
+fig.add_trace(
+    go.Bar(
+        x=top5["pop"],
+        y=top5["country"],
+        orientation="h",
+    )
+)
+
+# Update layout
+fig.update_layout(height=420)
+
+fig.show()
+```
+
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="sortbar-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="sortbar-desc">
+This bar chart uses the afcharts theme, and shows the populations of the five most populous countries in the Americas, sorted in ascending order by population. Each bar is dark blue and labelled by country underneath. All text is black in a sans serif font. Pale grey grid lines extend out from the y axis.
+</div>
+
+### Adding a horizontal or vertical line
+
+To add a horizontal or vertical line across the whole plot, use `add_hline()` or `add_vline()` respectively. Annotating the line can be achieved using `annotation_text` argument. This can be useful to highlight a threshold or average level.  
+
+```{python}
+# | output: false
+
+import plotly.graph_objects as go
+
+from afcharts.pio_template import pio
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+df = gapminder().query("country == 'United Kingdom'")
+
+# Create figure
+fig = go.Figure()
+
+# Add a trace
+fig.add_trace(
+    go.Scatter(
+        x=df["year"],
+        y=df["lifeExp"],
+        mode="lines",
+        name="United Kingdom",
+        text=df["country"],
+    )
+)
+
+
+# Add a dotted horizontal line for 70 years of age
+fig.add_hline(
+    y=70,
+    line_dash="dash",  # dashed line
+    line_color="gray",  # gray color
+    annotation_text="Age 70",  # label
+    annotation_position="top right",
+    annotation_font_size=14,
+    annotation_font_color="black",
+)
+
+# Update layout
+fig.update_layout(
+    xaxis=dict(
+        showgrid=False,  # Hide x-axis grid lines
+        dtick=10,  # Show ticks every 10 units
+        range=[1950, 2010],
+    ),
+    yaxis=dict(
+        range=[0, 82],
+        tickmode="linear",
+        dtick=10,  # Show ticks every 10 units
+    ),
+    showlegend=False,
+    height=400,
+    margin=dict(r=40),
+)
+
+fig.show()
+
+```
+
+<div class="chart-title">Living Longer</div>
+<div class="chart-subtitle">Life expectancy in the United Kingdom 1952 to 2007</div>
+<div class="chart" aria-describedby="hline-desc">
+
+```{python}
+#| echo: false
+
+fig.show()
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="hline-desc">
+This line chart uses the afcharts theme. There are pale grey grid lines extending from the y axis, and there is a thicker dark blue line representing the data. A dotted horizontal line has been added at 70 years of age, with an annotation to label it.
+</div>
+
+### Wrapping text
+
+If text is too long, it may be cut off or distort the dimensions of the chart. To avoid this, text can be wrapped to multiple lines using the `textwrap` module. The width argument controls how many characters are allowed on each line before wrapping. See the figure title below for an example.
+
+Alternatively, you can manually add line breaks by inserting `<br>` into the text string to control where the text is wrapped. See the y-axis label in the figure below for an example.
+
+```{python}
+# | output: false
+
+import textwrap
+import plotly.graph_objects as go
+
+from afcharts.pio_template import pio
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+
+top5 = df.nlargest(5, "pop")
+
+fig = go.Figure()
+
+fig.add_trace(
+    go.Bar(
+        x=top5["country"],
+        y=top5["pop"] / 1e6,
+    )
+)
+
+# Update layout
+fig.update_layout(
+    title="<br>".join(
+        textwrap.wrap(
+            "The U.S.A. is the most populous country in the Americas by a wide margin",
+            width=40,
+        )
+    ),  # Plotly does not support \n you must use a <br>
+    margin=dict(t=80),  # Increase top margin so the title is not clipped
+    yaxis=dict(title="Population<br>in millions"),  # Plotly does not support rotating axis labels
+    height=420,
+)
+
+fig.show()
+
+```
+
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="textwrap-desc">
+
+```{python}
+# | echo: false
+
+fig.show()
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="textwrap-desc">
+In this bar chart image, the y-axis label and chart title text have been wrapped onto two lines so that all the text is visible without being cut off.
+</div>

--- a/src/afcharts/cookbook/03-plotly-usage.qmd
+++ b/src/afcharts/cookbook/03-plotly-usage.qmd
@@ -746,6 +746,267 @@ fig.show()
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
 </div>
 
+
+## Choropleth map
+<!-- AF example followed: https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/ -->
+```{python}
+# | eval: true
+# | output: false
+
+import requests
+import pandas as pd
+import geopandas as gpd
+import plotly.graph_objects as go
+import io
+
+# Fetch indicator data
+url = "https://fingertips.phe.org.uk/api/all_data/csv/by_indicator_id?indicator_ids=41203"
+df = pd.read_csv(io.BytesIO(requests.get(url, verify=False).content))
+
+df = df[df["Time period"] == "2023/24"]  # This is the date in the analysis function website.
+
+# Numeric breakpoints for quantiles
+bins = [0, 2.4, 2.9, 3.5, 4.6, 12.7]
+
+# Labels in the same order
+labels = ["Lowest (0.0 to 2.4)", "(2.4 to 2.9)", "(2.9 to 3.5)", "(3.5 to 4.6)", "Highest (4.6 to 12.7)"]
+order = ["Suppressed"] + labels
+
+# Assign bin categories
+df["quantile_label"] = (
+    pd.cut(df["Value"], bins=bins, labels=labels, include_lowest=True)
+    .cat.add_categories("Suppressed")
+    .fillna("Suppressed")
+    .cat.reorder_categories(order, ordered=True)
+)
+
+# Get UK Country boundaries
+url = (
+    "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/"
+    "Countries_December_2023_Boundaries_UK_BUC/FeatureServer/0/query"
+    "?outFields=*&where=1%3D1&f=geojson"
+)
+country_boundaries = gpd.read_file(requests.get(url, verify=False).content).to_crs(4326)
+
+# Get Counties and Unitary Authorities
+url = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Counties_and_Unitary_Authorities_December_2023_Boundaries_UK_BUC/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson"
+gdf = gpd.read_file(requests.get(url, verify=False).content).to_crs(4326)
+
+# Filter to England only
+england_boundaries = country_boundaries[country_boundaries["CTRY23NM"] == "England"]
+gdf_clipped_strict = gpd.overlay(gdf, england_boundaries, how="intersection")
+
+merged = gdf_clipped_strict.merge(df, left_on="CTYUA23CD", right_on="Area Code", how="left").reset_index(drop=True)
+
+from afcharts.af_colours import get_af_colours
+from afcharts.pio_template import pio
+
+# Get the sequential colour palette in reverse order
+sequential = get_af_colours("sequential", number_of_colours=5, include_grey=True)[::-1]
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+fig = go.Figure()
+
+cat_to_code = {label: i + 1 for i, label in enumerate(labels)}
+z = merged["quantile_label"].map(cat_to_code)
+
+# Must add a separate trace for the 'Suppressed'.
+null_mask = ~pd.isna(z)
+fig.add_trace(
+    go.Choropleth(
+        geojson=merged.loc[null_mask].__geo_interface__,
+        locations=merged.loc[null_mask].index,
+        z=z[null_mask],
+        colorscale=sequential[1:],
+        zmin=0,
+        zmax=5,
+        marker_line_width=0.5,
+        marker_line_color="white",
+        showscale=False,  # hide continuous colorbar; we'll add a categorical legend
+        hoverinfo="skip",
+    )
+)
+
+# Suppressed values
+fig.add_trace(
+    go.Choropleth(
+        geojson=merged.loc[~null_mask].__geo_interface__,
+        locations=merged.loc[~null_mask].index,
+        z=[0] * (~null_mask).sum(),  # dummy z
+        colorscale=[[0, sequential[0]], [1, sequential[0]]],  # null colour
+        marker_line_width=0.5,
+        marker_line_color="white",
+        showscale=False,
+        hoverinfo="skip",
+    )
+)
+
+width = 700
+height = 375
+
+# Add a legend entry for each category using a dummy scatter trace
+for lab, col in zip(order[::-1], sequential[::-1]):
+    fig.add_trace(
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="markers",
+            marker=dict(size=10, color=col, symbol="square"),
+            name=lab,
+        )
+    )
+
+
+# Add outline of England
+fig.add_trace(
+    go.Choropleth(
+        geojson=england_boundaries.__geo_interface__,
+        locations=england_boundaries.index,  # these are indices we put into properties
+        z=[0],
+        colorscale=[[0, "rgba(0,0,0,0)"], [1, "rgba(0,0,0,0)"]],  # transparent fill
+        marker_line_color="black",
+        marker_line_width=1,
+        hoverinfo="skip",
+        showscale=False,
+    )
+)
+
+fig.update_layout(
+    showlegend=True,
+    width=width,
+    height=height,
+    margin=dict(l=0, r=0, t=0, b=0),
+    legend=dict(
+        title="Equal-sized quintiles of geographies",
+        x=0.06,
+        y=0.9,
+        xanchor="left",
+        yanchor="top",
+        font=dict(size=14),
+    ),
+    xaxis=dict(visible=False),
+    yaxis=dict(visible=False),
+)
+
+fig.update_geos(
+    projection_type="transverse mercator",
+    fitbounds="locations",
+    visible=False,
+)
+
+fig.show()
+```
+
+
+<div class="chart-title">Choropleth map with five series of sequential data</div>
+<div class="chart-subtitle">Rate of new certifications of visual impairment due to diabetic eye disease in persons aged 12 years and over, per 100,000 population</div>
+<div class="chart" aria-describedby="choropleth-desc">
+
+```{python}
+#| echo: false
+
+fig.show()
+
+```
+
+</div>
+<div class="chart-source">Source: Data used to create this map is available to download from the Fingertips Local Authority health profile produced by the Office for Health Improvement and Disparities.</div>
+
+<div class="chart-alt" id="choropleth-desc">
+The map shows the rate of new certifications of visual impairment (CVI) due to diabetic eye disease in persons aged 12 years and over by upper-tier local authority. The data has been broken down into five equal groups with the highest fifth of areas being in the category showing as darkest blue on the map, and areas with the lowest levels shown in the lightest blue.
+</div>
+
+## Heatmap
+<!-- Source: https://www.gov.uk/government/statistical-data-sets/monthly-domestic-energy-price-statistics -->
+```{python}
+# | eval: true
+# | output: false
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+import textwrap
+
+from afcharts.af_colours import get_af_colours
+from afcharts.pio_template import pio
+
+# Get the sequential colour palette
+sequential = get_af_colours("sequential", number_of_colours=5, include_grey=True)[::-1]
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+DATA_URL = "https://assets.publishing.service.gov.uk/media/69f1caf7c42061e837e3abfb/table_211_213__8_.xlsx"
+
+df = pd.read_excel(DATA_URL, sheet_name="2.1.1", header=11, skiprows=[12], usecols="A:B,J:P")
+
+df = (
+    df[df["Quarter"] == "Jan to Mar"]
+    .set_index("Year and dataset code row")
+    .drop(columns=["Quarter"])
+    .dropna(how="all")
+)
+df.index = df.index.astype("string")
+
+df.columns = (
+    df.columns.str.replace("Real terms price indices: ", "")
+    .str.replace(" [Note 3]", "")
+    .str.replace("\n[Note 1, 3]", "")
+    .str.replace("\n[Note 2, 3]", "")
+    .str.replace("CPI 2025=100\n[Note 3]", "")
+)
+
+for c in df.columns:
+    df[c] = pd.to_numeric(df[c], errors="coerce")
+
+fig = go.Figure()
+
+
+fig.add_trace(
+    go.Heatmap(
+        z=df.T,
+        x=df.index,
+        y=df.columns,
+        colorscale=sequential[1:],
+        colorbar=dict(title="CPI (2025 = 100)"),
+        hoverinfo="skip",
+    )
+)
+
+fig.update_layout(
+    height=600,
+    width=600,
+    xaxis=dict(
+        automargin=True,
+    ),
+)
+
+
+fig.show()
+```
+
+
+<div class="chart-title">Domestic energy price indices in real terms</div>
+<div class="chart-subtitle">Heat map of Quarterly consumer price indices of fuel components.</div>
+<div class="chart" aria-describedby="heatmap-desc">
+
+```{python}
+#| echo: false
+
+fig.show()
+
+```
+
+</div>
+<div class="chart-source">Source: https://www.gov.uk/government/statistical-data-sets/monthly-domestic-energy-price-statistics</div>
+
+<div class="chart-alt" id="heatmap-desc">
+Heatmap displaying domestic energy price indices for the January–March quarter by year and fuel type. Values are encoded using a colour scale from light to dark to represent lower to higher index values, enabling comparison across fuels and years.
+</div>
+
 ## Other customisations
 ### Sorting a bar chart
 

--- a/src/afcharts/cookbook/03-plotly-usage.qmd
+++ b/src/afcharts/cookbook/03-plotly-usage.qmd
@@ -1007,6 +1007,71 @@ fig.show()
 Heatmap displaying domestic energy price indices for the January–March quarter by year and fuel type. Values are encoded using a colour scale from light to dark to represent lower to higher index values, enabling comparison across fuels and years.
 </div>
 
+## Annotations
+
+Labelling your chart is often preferable to using a legend, as often this relies on a user matching the legend to the data using colour alone.
+
+You can add an annotation anywhere on a chart using the `fig.add_annotation()` method. This is demonstrated above in [Line chart with duo palette](#line-chart-with-duo-palette), which directly labels each line. Note that black text has been used for the labels, as this ensures sufficient contrast against the white background.
+
+To add value labels to bars in a bar chart, use the `text` argument of `go.Bar()`. In the example below, the population values are added as white text labels inside the bars.
+
+```{python}
+# | output: false
+
+import plotly.graph_objects as go
+
+from afcharts.pio_template import pio
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+# Filter for Americas in 2007 and get top 5 by population
+df = gapminder().query("year == 2007 & continent == 'Americas'")
+
+top5 = df.nlargest(5, "pop")
+
+fig = go.Figure()
+
+x = top5["country"]
+y = top5["pop"] / 1e6  # millions
+
+fig.add_trace(
+    go.Bar(
+        x=x,
+        y=y,
+        text=round(y, 2),
+        textposition="inside",
+        textfont=dict(color="white")
+    )
+)
+
+# Update layout
+fig.update_layout(height=420)
+
+fig.show()
+
+```
+
+<div class="chart-title">The U.S.A. is the most populous country in the Americas</div>
+<div class="chart-subtitle">Population of countries in the Americas (millions), 2007</div>
+<div class="chart" aria-describedby="barchart-annotated-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="barchart-annotated-desc">
+This bar chart uses the afcharts theme, and shows the populations of the five most populous countries in the Americas. Each bar is dark blue and labelled by country underneath. White text labels are added inside each bar showing the population value in millions. Pale grey grid lines extend out from the y axis.
+</div>
+
 ## Other customisations
 ### Sorting a bar chart
 

--- a/src/afcharts/cookbook/03-plotly-usage.qmd
+++ b/src/afcharts/cookbook/03-plotly-usage.qmd
@@ -1278,3 +1278,19 @@ fig.show()
 <div class="chart-alt" id="textwrap-desc">
 In this bar chart image, the y-axis label and chart title text have been wrapped onto two lines so that all the text is visible without being cut off.
 </div>
+
+
+## Reverting to plotly default template
+
+In some instances you may want to rever to the default plotly template after applying the 'afcharts' 'pio_template'.
+
+To do that run: 'pio.templates.default = "plotly"'
+
+```{python}
+# | output: false
+
+from afcharts.pio_template import pio
+
+# Revert to plotly's default theme
+pio.templates.default = "plotly"
+```

--- a/src/afcharts/cookbook/04-colour-palettes.qmd
+++ b/src/afcharts/cookbook/04-colour-palettes.qmd
@@ -24,7 +24,7 @@ get_af_colours("duo")
 
 ### Number of colours
 
-By default, `get_af_colours()` will return all colours in the given palette. For the categorical palette, the number of colours returned can be set with the `number_of_colours` argument.
+By default, `get_af_colours()` will return all core colours in the given palette with grey as an optional addition. For the categorical and sequential palettes, the number of colours returned can be set with the `number_of_colours` argument.
 
 For example, to return four colours from the categorical palette as hex codes:
 ```{python}
@@ -40,7 +40,7 @@ For example, to return the sequential colour palette as a list of rgb code tuple
 ```{python}
 #| eval: false
 get_af_colours("sequential", colour_format="rgb")                      
-# [(18, 67, 109), (32, 115, 188), (107, 172, 230)]
+# [(9, 33, 53), (18, 67, 109), (32, 115, 188), (107, 172, 230), (173, 209, 241)]
 ```
 
 
@@ -57,7 +57,7 @@ from afcharts.af_colours import get_af_colours
 
 cat = get_af_colours("categorical")
 duo = get_af_colours("duo")
-sequential = get_af_colours("sequential")
+sequential = get_af_colours("sequential", include_grey=True)
 focus = get_af_colours("focus")
 ```
 
@@ -102,6 +102,8 @@ display(HTML(df.to_html(escape=False, index=False)))
 
 ### Sequential palette
 The `sequential` colour palette should be used for data where the order has some meaning, such as age groups.
+
+The pale grey colour should be used for cases when, for example, you have no data or have suppressed the value. By default, the sequential palette returned by `get_af_colours()` does not include the pale grey. To include it, set `include_grey=True`.
 
 ```{python}
 #| echo: false

--- a/tests/af_colours_list_length_test.py
+++ b/tests/af_colours_list_length_test.py
@@ -18,8 +18,7 @@ from afcharts.af_colours import get_af_colours
 @pytest.mark.parametrize(
     "palette, colour_format, number_of_colours",
     [
-        # Test categorical palette for length boundaries (1–6 supported values)
-        ("categorical", "hex", 1),
+        # Test categorical palette for length boundaries (2–6 supported values)
         ("categorical", "hex", 2),
         ("categorical", "hex", 3),
         ("categorical", "hex", 4),
@@ -38,3 +37,11 @@ def test_categorical_list_length(palette, colour_format, number_of_colours):
     assert len(result) == number_of_colours, (
         f"Expected {number_of_colours} colours but got {len(result)} for palette='{palette}', format='{colour_format}'"
     )
+
+
+def test_categorical_minimum_colours_value():
+    """
+    Verify requesting 1 colour from the categorical palette triggers a ValueError.
+    """
+    with pytest.raises(ValueError):
+        get_af_colours("categorical", "hex", 1)

--- a/tests/af_colours_sequential_test.py
+++ b/tests/af_colours_sequential_test.py
@@ -1,0 +1,100 @@
+"""
+Tests for the sequential palette in `get_af_colours`.
+
+These tests verify:
+- Length: requesting 3, 4, or 5 colours returns the correct count.
+- Invalid values: requesting 1, 2, 6, 7, or 0 raises ValueError.
+- Exact values: 3, 4, and 5 return the guidance-specified hex lists.
+- Grey inclusion: include_grey=True appends the grey colour.
+"""
+
+import pytest
+
+from afcharts.af_colours import get_af_colours
+
+
+# Test valid list lengths
+@pytest.mark.parametrize(
+    "palette, colour_format, number_of_colours",
+    [
+        ("sequential", "hex", 3),
+        ("sequential", "hex", 4),
+        ("sequential", "hex", 5),
+        ("sequential", "rgb", 3),
+        ("sequential", "rgb", 4),
+        ("sequential", "rgb", 5),
+    ],
+)
+def test_sequential_list_length(palette, colour_format, number_of_colours):
+    """
+    Ensure the sequential palette returns exactly the requested number of colours.
+    """
+    result = get_af_colours(palette, colour_format, number_of_colours)
+    assert len(result) == number_of_colours
+
+# Test invalid values
+@pytest.mark.parametrize(
+    "palette, colour_format, number_of_colours",
+    [
+        ("sequential", "hex", 1),
+        ("sequential", "hex", 2),
+        ("sequential", "hex", 6),
+        ("sequential", "hex", 7),
+        ("sequential", "rgb", 0),
+    ],
+)
+def test_sequential_invalid_number_of_colours(palette, colour_format, number_of_colours):
+    """
+    Ensure invalid number_of_colours values raise ValueError.
+    """
+    with pytest.raises(ValueError):
+        get_af_colours(palette, colour_format, number_of_colours)
+
+# Test exact colour lists
+@pytest.mark.parametrize(
+    "number_of_colours, expected",
+    [
+        (3, ["#12436D", "#2073BC", "#6BACE6"]),
+        (4, ["#092135", "#12436D", "#2073BC", "#6BACE6"]),
+        (5, ["#092135", "#12436D", "#2073BC", "#6BACE6", "#ADD1F1"]),
+    ],
+)
+def test_sequential_exact_values(number_of_colours, expected):
+    """
+    Ensure sequential palettes return the exact hex values in the correct order.
+    """
+    result = get_af_colours("sequential", "hex", number_of_colours)
+    assert result == expected
+
+
+# Test with include_grey
+@pytest.mark.parametrize(
+    "number_of_colours, expected_length",
+    [
+        (3, 4),
+        (4, 5),
+        (5, 6),
+    ],
+)
+def test_sequential_list_length_with_grey(number_of_colours, expected_length):
+    """
+    Ensure the sequential palette with include_grey=True returns N+1 colours.
+    """
+    result = get_af_colours("sequential", "hex", number_of_colours, include_grey=True)
+    assert len(result) == expected_length
+
+
+@pytest.mark.parametrize(
+    "number_of_colours, expected",
+    [
+        (3, ["#12436D", "#2073BC", "#6BACE6", "#F2F2F2"]),
+        (4, ["#092135", "#12436D", "#2073BC", "#6BACE6", "#F2F2F2"]),
+        (5, ["#092135", "#12436D", "#2073BC", "#6BACE6", "#ADD1F1", "#F2F2F2"]),
+    ],
+)
+def test_sequential_exact_values_with_grey(number_of_colours, expected):
+    """
+    Ensure sequential palettes with include_grey=True return the correct hex values with grey appended.
+    """
+    result = get_af_colours("sequential", "hex", number_of_colours, include_grey=True)
+    assert result == expected

--- a/tests/af_colours_value_errors_test.py
+++ b/tests/af_colours_value_errors_test.py
@@ -22,7 +22,7 @@ def test_invalid_palette_value():
     Verify an invalid colour palette name triggers a ValueError.
     """
     with pytest.raises(ValueError):
-        get_af_colours("wrong_palette", "hex")
+        get_af_colours("wrong_palette", "hex")  # type: ignore[arg-type]
 
 
 def test_invalid_colour_format_value():
@@ -30,7 +30,7 @@ def test_invalid_colour_format_value():
     Verify an unsupported colour format triggers a ValueError.
     """
     with pytest.raises(ValueError):
-        get_af_colours("duo", "wrong_format")
+        get_af_colours("duo", "wrong_format")  # type: ignore[arg-type]
 
 
 def test_invalid_low_number_of_colours_value():

--- a/tests/matplotlib_bar_test.py
+++ b/tests/matplotlib_bar_test.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for the matplotlib bar charts using the af charts package.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import to_rgb
+
+
+def test_matplotlib_figure_creation():
+    """
+    Test that a matplotlib bar chart can be created with the afcharts style and that
+    bars are rendered on an Axes.
+    """
+    with plt.style.context("afcharts.afcharts"):
+
+        categories = ["A", "B", "C"]
+        values = [10, 15, 20]
+
+        fig, ax = plt.subplots()
+        bars = ax.bar(categories, values)
+
+        assert ax is not None
+        assert len(bars) == len(categories)
+
+        plt.close(fig)
+
+def test_matplotlib_style_figure_size():
+    """
+    Test that the afcharts style sets the default figure size to 6.4 x 4.8.
+    """
+    with plt.style.context('afcharts.afcharts'):
+
+        fig = plt.figure()
+
+        assert fig.get_figwidth() == 6.4
+        assert fig.get_figheight() == 4.8
+
+        plt.close(fig)
+
+def test_matplotlib_style_y_gridlines_visible():
+    """
+    Test that the afcharts style enables y-axis gridlines.
+    """
+    with plt.style.context('afcharts.afcharts'):
+
+        fig, ax = plt.subplots()
+
+        # Force the gridlines to be drawn to check their visibility
+        fig.canvas.draw()
+
+        y_gridlines = ax.get_ygridlines()
+        assert any(line.get_visible() for line in y_gridlines)
+
+        plt.close(fig)
+
+def test_matplotlib_default_colour_applied():
+    """
+    Test that a bar chart uses the first AF colour (dark blue) from the style.
+    """
+    with plt.style.context('afcharts.afcharts'):
+
+        fig, ax = plt.subplots()
+        ax.bar(["Stuff"], [10])
+
+        bar_patches = ax.patches
+        bar_colour = bar_patches[0].get_facecolor()[:3]
+
+        expected_colour = to_rgb("#12436D")
+
+        assert bar_colour == expected_colour
+
+        plt.close(fig)


### PR DESCRIPTION
## Description
adding instructions on plotly reverting template
### Summary
added a section at the bottom of the cookbook. I think it addresses both #168 #159 as I can't tell the difference between them

## Changes Made
<!-- List the main changes made in this PR -->

### Related Issues
<!-- Link to related issues using keywords like "Fixes #123", "Closes #456", "Relates to #789" -->
- Fixes #168
- Closes #168
- Relates to #159
