### PR TITLE
docs: add heat map, choropleth, and revert instructions to cookbook

### DIFF
--- a/docs/cookbook/02-matplotlib-usage.qmd
+++ b/docs/cookbook/02-matplotlib-usage.qmd
@@ -624,11 +624,11 @@ plt.style.use("afcharts.afcharts")
 
 DATA_URL = "https://assets.publishing.service.gov.uk/media/69f1caf7c42061e837e3abfb/table_211_213__8_.xlsx"
 
-df = pd.read_excel(DATA_URL, sheet_name="2.1.1", header=11, skiprows=[12], usecols="A:B,J:P")
+df = pd.read_excel(DATA_URL, sheet_name="2.1.1", header=7, usecols="A:B,J:P")
 
 df = (
     df[df["Quarter"] == "Jan to Mar"]
-    .set_index("Year and dataset code row")
+    .set_index("Year")
     .drop(columns=["Quarter"])
     .dropna(how="all")
 )

--- a/docs/cookbook/02-matplotlib-usage.qmd
+++ b/docs/cookbook/02-matplotlib-usage.qmd
@@ -597,6 +597,84 @@ fig
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
 </div>
 
+## Heatmap
+<!-- Source: https://www.gov.uk/government/statistical-data-sets/monthly-domestic-energy-price-statistics -->
+
+```{python}
+#| output: false
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
+
+from afcharts.af_colours import get_af_colours
+
+# Get the sequential colour palette
+sequential = get_af_colours("sequential", number_of_colours=5, include_grey=True)[::-1]
+
+# Slice the palette to remove the grey colour
+sequential_slice = sequential[1:]
+
+# Get a Matplotlib colormap from the sequential palette
+sequential_cmap = LinearSegmentedColormap.from_list("sequential", sequential_slice)
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+DATA_URL = "https://assets.publishing.service.gov.uk/media/69f1caf7c42061e837e3abfb/table_211_213__8_.xlsx"
+
+df = pd.read_excel(DATA_URL, sheet_name="2.1.1", header=11, skiprows=[12], usecols="A:B,J:P")
+
+df = (
+    df[df["Quarter"] == "Jan to Mar"]
+    .set_index("Year and dataset code row")
+    .drop(columns=["Quarter"])
+    .dropna(how="all")
+)
+df.index = df.index.astype("string")
+
+df.columns = (
+    df.columns.str.replace("Real terms price indices: ", "")
+    .str.replace(" [Note 3]", "")
+    .str.replace("\n[Note 1, 3]", "")
+    .str.replace("\n[Note 2, 3]", "")
+    .str.replace("CPI 2025=100\n[Note 3]", "")
+)
+
+for c in df.columns:
+    df[c] = pd.to_numeric(df[c], errors="coerce")
+
+fig = plt.figure(figsize=(5, 8))
+plt.imshow(df.T, aspect="auto", cmap=sequential_cmap)
+plt.gca().invert_yaxis()
+plt.xticks(labels=df.index[::10], ticks=np.arange(len(df.index))[::10])
+plt.yticks(labels=df.columns, ticks=np.arange(len(df.columns)))
+plt.grid(False)
+cbar = plt.colorbar(shrink=0.9)
+cbar.ax.set_title(label="CPI (2025 = 100)")
+fig
+
+```
+
+<div class="chart-title">Domestic energy price indices in real terms</div>
+<div class="chart-subtitle">Heat map of quarterly consumer price indices of fuel components.</div>
+<div class="chart" aria-describedby="heatmap-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: https://www.gov.uk/government/statistical-data-sets/monthly-domestic-energy-price-statistics</div>
+
+<div class="chart-alt" id="heatmap-desc">
+Heatmap displaying domestic energy price indices for the January–March quarter by year and fuel type. Values are encoded using a colour scale from light to dark to represent lower to higher index values, enabling comparison across fuels and years.
+</div>
+
 ## Annotations
 
 Labelling your chart is often preferable to using a legend, as often this relies on a user matching the legend to the data using colour alone.

--- a/docs/cookbook/02-matplotlib-usage.qmd
+++ b/docs/cookbook/02-matplotlib-usage.qmd
@@ -659,15 +659,19 @@ colour_map = dict(zip(labels, sequential))
 merged["colour"] = merged["quantile_label"].map(colour_map).fillna(sequential[0])
 
 fig, ax = plt.subplots(figsize=(8, 10))
+
+# Plot a choropleth map using the .plot() method of our geopandas dataframe
 merged.plot(ax=ax, color=merged["colour"], edgecolor="white", linewidth=0.5)
 
 # Add outline of England
 england_boundaries.plot(ax=ax, color="none", edgecolor="black", linewidth=1)
 
+# Add a legend entry for each category
 legend_patches = [
     Patch(color=colour, label=label)
     for label, colour in zip(labels, sequential)
 ]
+
 ax.legend(
     handles=legend_patches[::-1],
     loc="upper left",
@@ -675,6 +679,7 @@ ax.legend(
     title="Equal-sized quintiles of geographies",
     fontsize=14
 )
+
 ax.axis("off")
 
 fig
@@ -734,12 +739,9 @@ df = (
 )
 df.index = df.index.astype("string")
 
-df.columns = (
-    df.columns.str.replace("Real terms price indices: ", "")
-    .str.replace(" [Note 3]", "")
-    .str.replace("\n[Note 1, 3]", "")
-    .str.replace("\n[Note 2, 3]", "")
-    .str.replace("CPI 2025=100\n[Note 3]", "")
+df.columns = (  
+    df.columns.str.replace("Real terms price indices: ", "")  
+    .str.replace(r"(CPI 2025=100)?[ \\n]*\[Note [\d, ]+\]", "", regex=True)  
 )
 
 for c in df.columns:
@@ -747,12 +749,15 @@ for c in df.columns:
 
 fig = plt.figure(figsize=(5, 8))
 plt.imshow(df.T, aspect="auto", cmap=sequential_cmap)
+
 plt.gca().invert_yaxis()
 plt.xticks(labels=df.index[::10], ticks=np.arange(len(df.index))[::10])
 plt.yticks(labels=df.columns, ticks=np.arange(len(df.columns)))
 plt.grid(False)
+
 cbar = plt.colorbar(shrink=0.9)
 cbar.ax.set_title(label="CPI (2025 = 100)")
+
 fig
 
 ```

--- a/docs/cookbook/02-matplotlib-usage.qmd
+++ b/docs/cookbook/02-matplotlib-usage.qmd
@@ -597,9 +597,109 @@ fig
 This bar chart uses the afcharts theme, and shows the populations of five countries of the Americas in descending order. The country names are given on the x axis, with all chart text in black in a sans serif font. Four of the bars on the chart are light grey, and the bar for Brazil is filled in dark blue to highlight it.
 </div>
 
+## Choropleth map
+<!-- AF example followed: https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/ -->
+```{python}
+# | eval: true
+# | output: false
+
+import requests
+import pandas as pd
+import io
+import geopandas as gpd
+import matplotlib.pyplot as plt
+from afcharts.af_colours import get_af_colours
+from matplotlib.patches import Patch
+
+# Fetch indicator data
+url = "https://fingertips.phe.org.uk/api/all_data/csv/by_indicator_id?indicator_ids=41203"
+df = pd.read_csv(io.BytesIO(requests.get(url, verify=False).content))
+
+df = df[df["Time period"] == "2023/24"]  # This is the date in the analysis function website.
+
+# Numeric breakpoints for quantiles
+bins = [0, 2.4, 2.9, 3.5, 4.6, 12.7]
+
+# Create labels for the quantiles, with a label for suppressed values
+labels = ["Suppressed", "Lowest (0.0 to 2.4)", "(2.4 to 2.9)", "(2.9 to 3.5)", "(3.5 to 4.6)", "Highest (4.6 to 12.7)"]
+
+# Assign bin categories
+df["quantile_label"] = (
+    pd.cut(df["Value"], bins=bins, labels=labels[1:], include_lowest=True)
+    .cat.add_categories("Suppressed")
+    .fillna("Suppressed")
+)
+
+# Get UK Country boundaries
+url = (
+    "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/"
+    "Countries_December_2023_Boundaries_UK_BUC/FeatureServer/0/query"
+    "?outFields=*&where=1%3D1&f=geojson"
+)
+country_boundaries = gpd.read_file(requests.get(url, verify=False).content).to_crs(4326)
+
+# Get Counties and Unitary Authorities
+url = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/Counties_and_Unitary_Authorities_December_2023_Boundaries_UK_BUC/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson"
+gdf = gpd.read_file(requests.get(url, verify=False).content).to_crs(4326)
+
+# Filter to England only
+england_boundaries = country_boundaries[country_boundaries["CTRY23NM"] == "England"]
+gdf_clipped_strict = gpd.overlay(gdf, england_boundaries, how="intersection")
+
+merged = gdf_clipped_strict.merge(df, left_on="CTYUA23CD", right_on="Area Code", how="left").reset_index(drop=True)
+
+# Get the sequential colour palette in reverse order
+sequential = get_af_colours("sequential", number_of_colours=5, include_grey=True)[::-1]
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+colour_map = dict(zip(labels, sequential))
+
+merged["colour"] = merged["quantile_label"].map(colour_map).fillna(sequential[0])
+
+fig, ax = plt.subplots(figsize=(8, 10))
+merged.plot(ax=ax, color=merged["colour"], edgecolor="white", linewidth=0.5)
+
+# Add outline of England
+england_boundaries.plot(ax=ax, color="none", edgecolor="black", linewidth=1)
+
+legend_patches = [
+    Patch(color=colour, label=label)
+    for label, colour in zip(labels, sequential)
+]
+ax.legend(
+    handles=legend_patches[::-1],
+    loc="upper left",
+    borderaxespad=-2, # to achieve acceptable spacing between legend and map
+    title="Equal-sized quintiles of geographies",
+    fontsize=14
+)
+ax.axis("off")
+
+fig
+```
+
+<div class="chart-title">Choropleth map with five series of sequential data</div>
+<div class="chart-subtitle">Rate of new certifications of visual impairment due to diabetic eye disease in persons aged 12 years and over, per 100,000 population</div>
+<div class="chart" aria-describedby="choropleth-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Data used to create this map is available to download from the Fingertips Local Authority health profile produced by the Office for Health Improvement and Disparities.</div>
+
+<div class="chart-alt" id="choropleth-desc">
+The map shows the rate of new certifications of visual impairment (CVI) due to diabetic eye disease in persons aged 12 years and over by upper-tier local authority. The data has been broken down into five equal groups with the highest fifth of areas being in the category showing as darkest blue on the map, and areas with the lowest levels shown in the lightest blue.
+</div>
+
 ## Heatmap
 <!-- Source: https://www.gov.uk/government/statistical-data-sets/monthly-domestic-energy-price-statistics -->
-
 ```{python}
 #| output: false
 
@@ -886,3 +986,16 @@ fig
 <div class="chart-alt" id="textwrap-desc">
 In this bar chart image, the y-axis label and chart title text have been wrapped onto two lines so that all the text is visible without being cut off.
 </div>
+
+## Revert to Matplotlib default
+
+To revert to Matplotlib's default settings after applying the afcharts style:
+
+```{python}
+# | output: false
+
+import matplotlib.pyplot as plt
+
+# Revert to Matplotlib's default style
+plt.style.use("default")
+```


### PR DESCRIPTION
## Description

### Summary
<!-- Provide a brief description of the changes in this PR -->
This PR adds the following Matplotlib sections to the cookbook:
- choropleth
-  heat map
- revert to default

## Changes Made
<!-- List the main changes made in this PR -->
As above. 

I ended up consolidating everything into one PR, but noticed that between the two sessions that I spent putting this together, the heat map code which relies on the Excel document broke so had to rework it (the position of the headers changed, as well as their names). Might be worth @rodriguesfred having a look at the Plotly stuff. That said, it rendered OK on my side which made it even more confusing!

### Related Issues
<!-- Link to related issues using keywords like "Fixes #123", "Closes #456", "Relates to #789" -->
- Closes #173, #155
