### PR TITLE
fix: update PyPI Development Status to Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
 ]
 requires-python = ">=3.10"
 


### PR DESCRIPTION
The "Development Status" classifier on the [afcharts PyPI page](https://pypi.org/project/afcharts/1.1.0/) currently shows "Alpha". This PR updates it to "Production/Stable".
