### PR TITLE
fix: removing choropleth interactivity

### DIFF
--- a/docs/cookbook/03-plotly-usage.qmd
+++ b/docs/cookbook/03-plotly-usage.qmd
@@ -906,7 +906,7 @@ fig.update_geos(
     visible=False,
 )
 
-fig.show()
+fig.show(config={"staticPlot": True})
 ```
 
 
@@ -915,9 +915,9 @@ fig.show()
 <div class="chart" aria-describedby="choropleth-desc">
 
 ```{python}
-#| echo: false
+# | echo: false
 
-fig.show()
+fig.show(config={"staticPlot": True})
 
 ```
 

--- a/docs/cookbook/03-plotly-usage.qmd
+++ b/docs/cookbook/03-plotly-usage.qmd
@@ -906,7 +906,9 @@ fig.update_geos(
     visible=False,
 )
 
-fig.show(config={"staticPlot": True})
+fig.show(
+    config={"staticPlot": True} # Show figure as a static plot to avoid unintended interactivity
+)
 ```
 
 
@@ -917,7 +919,9 @@ fig.show(config={"staticPlot": True})
 ```{python}
 # | echo: false
 
-fig.show(config={"staticPlot": True})
+fig.show(
+    config={"staticPlot": True} # Show figure as a static plot to avoid unintended interactivity
+)
 
 ```
 


### PR DESCRIPTION
## Description
removing choropleth interactivity.

We could remove the one from the first fig.show() for simplicity. the one last one is the crucial one for the quarto

### Summary
<!-- Provide a brief description of the changes in this PR -->

## Changes Made
<!-- List the main changes made in this PR -->

### Related Issues
<!-- Link to related issues using keywords like "Fixes #123", "Closes #456", "Relates to #789" -->
- Fixes #199 
- Closes #199 
- Relates to #
