### PR TITLE
docs: afcharts launch blog post

### DIFF
--- a/docs/images/example_charts/example_charts.ipynb
+++ b/docs/images/example_charts/example_charts.ipynb
@@ -5,7 +5,138 @@
    "id": "4efa35ee",
    "metadata": {},
    "source": [
-    "This notebook produces example charts for the README. They are saved in the current folder as PNGs."
+    "This notebook produces example charts for use in the README, blog posts etc. They are saved in the current folder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6027ad35",
+   "metadata": {},
+   "source": [
+    "## Launch blog post\n",
+    "\n",
+    "These charts were used for the afcharts official launch blog post on the Analysis Function website. See [launch-blog-post.md](../../launch-blog-post.md) for the blog text. They are saved as SVG files as recommended for web.\n",
+    "\n",
+    "Unlike the charts in the cookbook, the y-axis titles are embedded in the saved plots because we don't have control over the formatting used on the AF website."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bafaf6d",
+   "metadata": {},
+   "source": [
+    "### Blog: Two-line chart\n",
+    "\n",
+    "Demonstrates basic functionality, the duo line palette, and line labelling in place of a legend, as is best practice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa6d0ba8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Load gapminder dataset from plotly\n",
+    "from plotly.express.data import gapminder\n",
+    "\n",
+    "from afcharts.af_colours import get_af_colours\n",
+    "\n",
+    "# Get the duo colour palette\n",
+    "duo = get_af_colours(\"duo\")\n",
+    "\n",
+    "df = gapminder()\n",
+    "df = df[df[\"country\"].isin([\"United Kingdom\", \"China\"])]\n",
+    "\n",
+    "plt.style.use(\"afcharts.afcharts\")\n",
+    "\n",
+    "# Make the figure wider than the default (6.4, 4.8)\n",
+    "fig, ax = plt.subplots(figsize=(8.5, 4.8))\n",
+    "\n",
+    "for i, (country, data) in enumerate(df.groupby(\"country\")):\n",
+    "    plt.plot(data[\"year\"], data[\"lifeExp\"], label=country, color=duo[i])\n",
+    "    ax.annotate(\n",
+    "        country,\n",
+    "        xy=(data[\"year\"].values[-1], data[\"lifeExp\"].values[-1]),\n",
+    "        xytext=(6, 0),\n",
+    "        textcoords=\"offset points\",\n",
+    "        bbox=dict(boxstyle=\"square\", fc=\"white\", lw=0),  # Add a white background\n",
+    "    )\n",
+    "\n",
+    "plt.xlim([1950, 2010])\n",
+    "plt.ylim([0, 85])\n",
+    "plt.title(\"Life expectancy (years)\")\n",
+    "\n",
+    "plt.savefig(\"line_chart-matplotlib_afcharts.svg\",\n",
+    "            bbox_inches='tight')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f89b74f9",
+   "metadata": {},
+   "source": [
+    "### Blog: Small multiples area chart\n",
+    "\n",
+    "Demonstrates the categorical colour palette and multiple axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "668a8ba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.ticker import FuncFormatter\n",
+    "\n",
+    "# Load the gapminder dataset from plotly.express\n",
+    "from plotly.express.data import gapminder\n",
+    "\n",
+    "from afcharts.af_colours import get_af_colours\n",
+    "\n",
+    "# Get the categorical colour palette\n",
+    "categorical = get_af_colours(\"categorical\")\n",
+    "\n",
+    "# Set default theme\n",
+    "plt.style.use(\"afcharts.afcharts\")\n",
+    "\n",
+    "df = gapminder()\n",
+    "\n",
+    "# Filter out Oceania and aggregate population by continent and year\n",
+    "df_grouped = (\n",
+    "    df[df[\"continent\"] != \"Oceania\"]\n",
+    "    .groupby([\"continent\", \"year\"], observed=True)[\"pop\"].sum()\n",
+    "    .reset_index()\n",
+    ")\n",
+    "\n",
+    "# Define the continents to plot\n",
+    "continents = df_grouped[\"continent\"].unique()\n",
+    "\n",
+    "# Create a 2x2 subplot layout\n",
+    "fig, axes = plt.subplots(\n",
+    "    ncols=2, nrows=2, sharex=True, sharey=True, constrained_layout=True\n",
+    ")\n",
+    "\n",
+    "# Make custom formatter for tick labels\n",
+    "def tick_billions(x, pos):\n",
+    "    if x == 0:\n",
+    "        return \"0\"\n",
+    "    else:\n",
+    "        return f\"{x / 1e9:.0f}bn\"\n",
+    "\n",
+    "# Add data to each set of axes\n",
+    "for idx, (continent, ax) in enumerate(zip(continents, axes.flat)):\n",
+    "    data = df_grouped[df_grouped[\"continent\"] == continent]\n",
+    "    ax.fill_between(x=data[\"year\"], y1=data[\"pop\"], y2=0, color=categorical[idx])\n",
+    "    ax.yaxis.set_major_formatter(FuncFormatter(tick_billions))\n",
+    "    ax.set_title(continent, loc=\"center\")\n",
+    "\n",
+    "plt.savefig(\"area_chart-matplotlib_afcharts.svg\",\n",
+    "            bbox_inches='tight')"
    ]
   },
   {
@@ -13,15 +144,21 @@
    "id": "0a6a1c38",
    "metadata": {},
    "source": [
-    "# Line chart"
+    "## README: Example charts\n",
+    "\n",
+    "These charts are shown at the top of the README as examples of afcharts-styled charts.\n",
+    "\n",
+    "Unlike the charts in the cookbook, the chart titles are embedded in the plots because we can't position them correctly in the markdown document."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "222a1f92",
+   "id": "eb535fd3",
    "metadata": {},
    "source": [
-    "## Matplotlib afcharts"
+    "### Two-line chart: Matplotlib - afcharts\n",
+    "\n",
+    "Note: This plot uses a legend rather than directly labelling the lines (as is best practice) because otherwise it would be too wide."
    ]
   },
   {
@@ -33,11 +170,13 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "# Import the duo palette\n",
-    "from afcharts.assets.af_colours import duo\n",
-    "\n",
     "# Load gapminder dataset from plotly\n",
     "from plotly.express.data import gapminder\n",
+    "\n",
+    "from afcharts.af_colours import get_af_colours\n",
+    "\n",
+    "# Get the duo colour palette\n",
+    "duo = get_af_colours(\"duo\")\n",
     "\n",
     "df = gapminder()\n",
     "df = df[df[\"country\"].isin([\"United Kingdom\", \"China\"])]\n",
@@ -65,18 +204,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00315721",
+   "id": "fb90ed42",
    "metadata": {},
    "source": [
-    "# Scatterplots"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "df0f6d03",
-   "metadata": {},
-   "source": [
-    "## Matplotlib afcharts"
+    "### Scatterplot: Matplotlib - afcharts"
    ]
   },
   {
@@ -87,13 +218,15 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# Import the duo palette\n",
-    "from afcharts.assets.af_colours import duo\n",
     "from matplotlib.ticker import StrMethodFormatter\n",
     "\n",
     "# Load gapminder dataset from plotly\n",
     "from plotly.express.data import gapminder\n",
+    "\n",
+    "from afcharts.af_colours import get_af_colours\n",
+    "\n",
+    "# Get the duo colour palette\n",
+    "duo = get_af_colours(\"duo\")\n",
     "\n",
     "# Set default theme\n",
     "plt.style.use(\"afcharts.afcharts\")\n",
@@ -126,24 +259,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "216830ae",
+   "id": "881dcb84",
    "metadata": {},
    "source": [
-    "# Bar chart"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5f5ae129",
-   "metadata": {},
-   "source": [
-    "## Matplotlib default"
+    "### Bar chart: Matplotlib - afcharts"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d74db979",
+   "id": "396c3f0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,59 +278,10 @@
     "# Load gapminder dataset from plotly\n",
     "from plotly.express.data import gapminder\n",
     "\n",
-    "# Load gapminder data from plotly\n",
-    "df = gapminder().query(\"year in [1967, 2007] and country in ['United Kingdom', 'Ireland', 'France', 'Belgium']\")\n",
+    "from afcharts.af_colours import get_af_colours\n",
     "\n",
-    "countries = ['United Kingdom', 'Ireland', 'France', 'Belgium']\n",
-    "years = [1967, 2007]\n",
-    "bar_width = 0.35\n",
-    "x = np.arange(len(countries))\n",
-    "\n",
-    "fig = plt.figure()\n",
-    "\n",
-    "for i, year in enumerate(years):\n",
-    "    data = df[df[\"year\"] == year].set_index(\"country\").reindex(countries)\n",
-    "    plt.bar(\n",
-    "        x + i * bar_width,\n",
-    "        data[\"lifeExp\"],\n",
-    "        width=bar_width,\n",
-    "        label=str(year)\n",
-    "    )\n",
-    "plt.xticks(x + bar_width / 2, countries)\n",
-    "plt.title(\"Life expectancy (years)\")\n",
-    "plt.legend(\n",
-    "    loc=\"lower center\",\n",
-    "    bbox_to_anchor=(0.5, -0.25),\n",
-    "    ncol=2\n",
-    ")\n",
-    "\n",
-    "plt.savefig(\"bar_chart-matplotlib_default.png\",\n",
-    "            bbox_inches='tight')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "190bb942",
-   "metadata": {},
-   "source": [
-    "## Matplotlib afcharts"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bde07e11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "# Import the duo palette\n",
-    "from afcharts.assets.af_colours import duo\n",
-    "\n",
-    "# Load gapminder dataset from plotly\n",
-    "from plotly.express.data import gapminder\n",
+    "# Get the duo colour palette\n",
+    "duo = get_af_colours(\"duo\")\n",
     "\n",
     "# Set default theme\n",
     "# plt.style.use(\"afcharts.afcharts\")\n",
@@ -244,10 +320,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "216830ae",
+   "metadata": {},
+   "source": [
+    "## README: Before and after afcharts\n",
+    "\n",
+    "Matplotlib and Plotly Bar charts with and without afcharts styling for the README.\n",
+    "\n",
+    "Unlike the charts in the cookbook, the chart titles are embedded in the plots because we can't position them correctly in the markdown document."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f5ae129",
+   "metadata": {},
+   "source": [
+    "### Bar chart: Matplotlib - default"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d74db979",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Load gapminder dataset from plotly\n",
+    "from plotly.express.data import gapminder\n",
+    "\n",
+    "# Set default theme\n",
+    "plt.style.use(\"default\")\n",
+    "\n",
+    "# Load gapminder data from plotly\n",
+    "df = gapminder().query(\"year in [1967, 2007] and country in ['United Kingdom', 'Ireland', 'France', 'Belgium']\")\n",
+    "\n",
+    "countries = ['United Kingdom', 'Ireland', 'France', 'Belgium']\n",
+    "years = [1967, 2007]\n",
+    "bar_width = 0.35\n",
+    "x = np.arange(len(countries))\n",
+    "\n",
+    "fig = plt.figure()\n",
+    "\n",
+    "for i, year in enumerate(years):\n",
+    "    data = df[df[\"year\"] == year].set_index(\"country\").reindex(countries)\n",
+    "    plt.bar(\n",
+    "        x + i * bar_width,\n",
+    "        data[\"lifeExp\"],\n",
+    "        width=bar_width,\n",
+    "        label=str(year)\n",
+    "    )\n",
+    "plt.xticks(x + bar_width / 2, countries)\n",
+    "plt.title(\"Life expectancy (years)\")\n",
+    "plt.legend(\n",
+    "    loc=\"lower center\",\n",
+    "    bbox_to_anchor=(0.5, -0.25),\n",
+    "    ncol=2\n",
+    ")\n",
+    "\n",
+    "plt.savefig(\"bar_chart-matplotlib_default.png\",\n",
+    "            bbox_inches='tight')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "65dedc0d",
    "metadata": {},
    "source": [
-    "## Plotly default"
+    "### Bar chart: Plotly - default"
    ]
   },
   {
@@ -309,7 +451,7 @@
    "id": "6d837118",
    "metadata": {},
    "source": [
-    "## Plotly afcharts"
+    "### Bar chart: Plotly - afcharts"
    ]
   },
   {
@@ -321,12 +463,15 @@
    "source": [
     "import plotly.express as px\n",
     "import plotly.graph_objects as go\n",
+    "import plotly.io as pio\n",
     "\n",
-    "# AF Package\n",
-    "from afcharts.assets.af_colours import duo\n",
+    "from afcharts.af_colours import get_af_colours\n",
+    "\n",
+    "# Get the duo colour palette\n",
+    "duo = get_af_colours(\"duo\")\n",
     "\n",
     "# Set default theme\n",
-    "# pio.templates.default = \"afcharts\"\n",
+    "pio.templates.default = \"afcharts\"\n",
     "\n",
     "# Load the gapminder dataset from plotly.express\n",
     "df = px.data.gapminder().query(\"year in [1967, 2007] & country in ['United Kingdom', 'Ireland', 'France', 'Belgium']\")\n",
@@ -387,7 +532,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "afcharts_py2",
+   "display_name": "afcharts_1",
    "language": "python",
    "name": "python3"
   },
@@ -401,7 +546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/docs/images/example_charts/example_charts.ipynb
+++ b/docs/images/example_charts/example_charts.ipynb
@@ -129,7 +129,7 @@
     "        return f\"{x / 1e9:.0f}bn\"\n",
     "\n",
     "# Add data to each set of axes\n",
-    "for idx, (continent, ax) in enumerate(zip(continents, axes.flat)):\n",
+    "for idx, (continent, ax) in enumerate(zip(continents, axes.flat, strict=False)):\n",
     "    data = df_grouped[df_grouped[\"continent\"] == continent]\n",
     "    ax.fill_between(x=data[\"year\"], y1=data[\"pop\"], y2=0, color=categorical[idx])\n",
     "    ax.yaxis.set_major_formatter(FuncFormatter(tick_billions))\n",

--- a/docs/launch-blog-post.md
+++ b/docs/launch-blog-post.md
@@ -1,0 +1,65 @@
+# afcharts for Python: accessible charts made easier
+
+The [Analysis Function data visualisation guidance](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-charts/) helps analysts create charts that are clear, impactful and accessible to all users. But applying it by hand — choosing the right fonts, colours, gridlines and layout for every chart — takes time and leaves room for mistakes. The [afcharts R package](https://best-practice-and-impact.github.io/afcharts/) has long solved this for R users. Now afcharts is available for Python too.
+
+afcharts automatically applies the recommended styles and [accessible colour palettes](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/) to your charts. Write your chart as normal in Matplotlib or Plotly — afcharts handles the rest.
+
+## Getting started
+
+Install afcharts from PyPI with a single command:
+
+```bash
+pip install afcharts
+```
+
+Then apply the afcharts style to all your charts. For Matplotlib:
+
+```python
+import matplotlib.pyplot as plt
+plt.style.use('afcharts.afcharts')
+```
+
+For Plotly:
+
+```python
+from afcharts.pio_template import pio
+pio.templates.default = "afcharts"
+```
+
+Every chart you create after running these lines will have the recommended fonts, axes, gridlines and layout automatically.
+
+## Accessible colour palettes
+
+The `get_af_colours()` function returns colours from the [Analysis Function colour palettes](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/). There are four palettes to choose from: categorical (up to 6 groups), duo (comparisons), sequential (ordered data) and focus (highlight a single series). Each palette is designed to be accessible and easy to distinguish.
+
+```python
+from afcharts.af_colours import get_af_colours
+colours = get_af_colours("categorical")
+```
+
+## Example charts
+
+With afcharts, the core formatting in both charts below came for free — fonts, axes, gridlines and layout applied automatically.
+
+**Figure 1: Life expectancy in the UK and China, 1952 to 2007**
+
+[IMAGE (docs\images\example_charts\line_chart-matplotlib_afcharts.svg): A line chart showing life expectancy over time in the UK and China, using the duo colour palette. | alt text: Line chart showing life expectancy in China and the UK from 1952 to 2007, styled with the afcharts duo colour palette. Two lines rise from 1952 to 2007, with China showing a steeper increase.]
+Full code: [Matplotlib](https://best-practice-and-impact.github.io/afcharts-py/02-matplotlib-usage.html#line-chart-with-duo-palette) | [Plotly](https://best-practice-and-impact.github.io/afcharts-py/03-plotly-usage.html#line-chart-with-duo-palette)
+
+**Figure 2: Population by continent, 1952 to 2007**
+
+[IMAGE (docs\images\example_charts\area_chart-matplotlib_afcharts.svg): A small multiples area chart showing population over time by continent from 1952 to 2007. | alt text: Small multiples area chart showing population growth by continent from 1952 to 2007 in Africa, Asia, Europe and the Americas, styled with afcharts. Each panel displays one continent with a shaded area beneath the line.]
+Full code: [Matplotlib](https://best-practice-and-impact.github.io/afcharts-py/02-matplotlib-usage.html#small-multiples) | [Plotly](https://best-practice-and-impact.github.io/afcharts-py/03-plotly-usage.html#small-multiples)
+
+## The afcharts cookbook
+
+The [afcharts cookbook](https://best-practice-and-impact.github.io/afcharts-py/) contains full, reusable code examples for common chart types — including bar charts, scatter plots and maps — in both Matplotlib and Plotly.
+
+The cookbook goes beyond what afcharts applies automatically, covering techniques such as [text wrapping](https://best-practice-and-impact.github.io/afcharts-py/02-matplotlib-usage.html#wrapping-text) to improve readability and [chart annotations](https://best-practice-and-impact.github.io/afcharts-py/03-plotly-usage.html#annotations) to supplement or replace legends that rely on colour alone. Each example is designed to be copied and adapted for your own charts, saving you time and helping you consistently meet the Analysis Function guidance.
+
+## Give feedback
+
+We welcome your feedback. If you find a bug or want to suggest a feature, raise an issue on our [GitHub](https://github.com/best-practice-and-impact/afcharts-py). For general questions, start a thread on [GitHub Discussions](https://github.com/best-practice-and-impact/afcharts-py/discussions).
+
+
+*Thank you to the Data Visualisation Python Tools group in the GSS Presentation Champions Network for building this package. The afcharts Python package builds on the afcharts R package and the py-af-colours package.*


### PR DESCRIPTION
## Description

### Summary
Adds text and example charts for the afcharts launch blog post to be published on the Government Analysis Function website.

## Changes Made

- Adds blog post text
- Add code for blog post example charts
- Fixes code for existing example charts (used in README) to use the new colour functions
- Labels and reorders the code for readability

### Related Issues
- Closes #136 
