### PR TITLE
docs(cookbook): add doughnut chart code example

### DIFF
--- a/docs/cookbook/02-matplotlib-usage.qmd
+++ b/docs/cookbook/02-matplotlib-usage.qmd
@@ -538,6 +538,84 @@ fig
 <div class="chart-alt" id="pie-desc">
 This pie chart uses the afcharts theme, showing the proportions of European countries with a life expectancy under and over 75. The segment colours are from the Analysis Function categorical palette, with the smaller under 75 segment in dark blue, and the larger over 75 segment in orange. This is indicated by labels next to each segment. There is whitespace separating the segments from each other.</div>
 
+### Doughnut charts
+
+Doughnut charts are fundamentally the same as pie charts but are presented with a hole in the centre of the chart to resemble a doughnut instead of a pie.
+
+```{python}
+# | eval: true
+# | output: false
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter
+
+from afcharts.af_colours import get_af_colours
+
+# Get the duo colour palette
+duo = get_af_colours("duo")
+
+# Set default theme
+plt.style.use("afcharts.afcharts")
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+df = gapminder().query("continent == 'Europe' and year == 2007")
+
+# Create life expectancy groups
+df["lifeExpGrouped"] = pd.cut(
+    df["lifeExp"],
+    bins=[0, 75, float("inf")],
+    labels=["Under 75", "75 and over"]
+)
+
+# Count number of countries in each group
+group_counts = df["lifeExpGrouped"].value_counts().sort_index()
+
+fig = plt.figure()
+patches, labels, texts = plt.pie(
+    group_counts.values,
+    labels=group_counts.index,
+    autopct="%1.0f%%",
+    pctdistance=0.73,
+    colors=duo,
+    wedgeprops={"edgecolor": "white", "linewidth": 2},
+)
+
+# Draw circle to use for doughnut hole
+centre_circle = plt.Circle((0, 0), 0.50, fc='white')
+fig = plt.gcf()
+
+# Add circle onto the Pie chart
+fig.gca().add_artist(centre_circle)
+
+textcolours = ["white", "black"]
+
+# Set the text to contrasting colours
+for i, text in enumerate(texts):
+    text.set_color(textcolours[i])
+
+fig
+```
+
+<div class="chart-title">How life expectancy varies in Europe</div>
+<div class="chart-subtitle">Percentage of countries by life expectancy band, 2007</div>
+<div class="chart" aria-describedby="pie-desc">
+
+```{python}
+#| echo: false
+
+fig
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="pie-desc">
+This doughnut chart uses the afcharts theme, showing the proportions of European countries with a life expectancy under and over 75. The segment colours are from the Analysis Function categorical palette, with the smaller under 75 segment in dark blue, and the larger over 75 segment in orange. This is indicated by a legend to the right of the doughnut chart. There is whitespace separating the segments from each other.
+</div>
+
 ## Focus charts
 ```{python}
 # | eval: true

--- a/docs/cookbook/03-plotly-usage.qmd
+++ b/docs/cookbook/03-plotly-usage.qmd
@@ -679,6 +679,86 @@ fig.show()
 This pie chart uses the afcharts theme, showing the proportions of European countries with a life expectancy under and over 75. The segment colours are from the Analysis Function categorical palette, with the smaller under 75 segment in dark blue, and the larger over 75 segment in orange. This is indicated by a legend to the right of the pie chart. There is whitespace separating the segments from each other.
 </div>
 
+### Doughnut charts
+
+Doughnut charts are fundamentally the same as pie charts but are presented with a hole in the centre of the chart to resemble a doughnut instead of a pie.
+
+```{python}
+# | eval: true
+# | output: false
+
+import plotly.express as px
+import plotly.graph_objects as go
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from afcharts.pio_template import pio
+
+from afcharts.af_colours import get_af_colours
+
+# Get the duo colour palette
+duo = get_af_colours("duo")
+
+# Set default theme
+pio.templates.default = "afcharts"
+
+# Load the gapminder dataset from plotly.express
+from plotly.express.data import gapminder
+
+df = gapminder().query("continent == 'Europe' and year == 2007")
+
+# Create life expectancy groups
+df["lifeExpGrouped"] = pd.cut(
+    df["lifeExp"],
+    bins=[0, 75, float("inf")],
+    labels=["Under 75", "75 and over"]
+)
+
+# Count number of countries in each group
+group_counts = df["lifeExpGrouped"].value_counts().sort_index()
+
+fig = go.Figure(
+    data=[
+        go.Pie(
+            values=group_counts.values,
+            labels=group_counts.index,
+            marker=dict(colors=duo, line=dict(color="white", width=2)),
+            sort=False,
+            hole=0.5,
+            textinfo="label+percent",
+            textposition="outside",
+            texttemplate="%{label}<br>(%{percent:.0%})",
+        )
+    ]
+)
+
+# Update layout
+fig.update_layout(
+    height=400,
+    showlegend=False
+)
+
+fig.show()
+
+```
+
+<div class="chart-title">How life expectancy varies in Europe</div>
+<div class="chart-subtitle">Percentage of countries by life expectancy band, 2007</div>
+<div class="chart" aria-describedby="pie-desc">
+
+```{python}
+#| echo: false
+
+fig.show()
+
+```
+
+</div>
+<div class="chart-source">Source: Gapminder</div>
+<div class="chart-alt" id="pie-desc">
+This doughnut chart uses the afcharts theme, showing the proportions of European countries with a life expectancy under and over 75. The segment colours are from the Analysis Function categorical palette, with the smaller under 75 segment in dark blue, and the larger over 75 segment in orange. This is indicated by a legend to the right of the doughnut chart. There is whitespace separating the segments from each other.
+</div>
+
 ## Focus charts
 ```{python}
 # | eval: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "afcharts"
-version = "1.1.1"
+version = "1.1.2rc1"
 description = "A python package to produce charts following UK Government Analysis Function guidance"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "afcharts"
-version = "1.1.0"
+version = "1.1.1"
 description = "A python package to produce charts following UK Government Analysis Function guidance"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "afcharts"
-version = "1.1.2rc1"
+version = "1.1.2"
 description = "A python package to produce charts following UK Government Analysis Function guidance"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Description

### Summary
<!-- Provide a brief description of the changes in this PR -->
This change updates the cookbook to include an extra section for both plotly and matplotlib with an example of code to produce a doughnut chart.

(I have forked this repo so I think there are a few extra commits from the main branch that haven't been merged into dev - not sure if this is an issue)

## Changes Made
<!-- List the main changes made in this PR -->

- Added doughnut chart code example for plotly page
- Added doughnut chart code example for matplotlib page

### Related Issues
<!-- Link to related issues using keywords like "Fixes #123", "Closes #456", "Relates to #789" -->
- Closes #200 
- Relates to #200 
